### PR TITLE
feat: support for single parameter eq INTELLIJ-108

### DIFF
--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/EditorToolbarDecorator.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/EditorToolbarDecorator.kt
@@ -68,7 +68,7 @@ class EditorToolbarDecorator(
     }
 
     override fun selectionChanged(event: FileEditorManagerEvent) {
-        ApplicationManager.getApplication().runReadAction {
+        ApplicationManager.getApplication().invokeLater {
             val editorService = project?.let {
                 if (it.isDisposed) {
                     null
@@ -78,13 +78,13 @@ class EditorToolbarDecorator(
             }
 
             toolbar?.let {
-                editorService?.toggleToolbarForSelectedEditor(it, false)
+                editorService?.toggleToolbarForSelectedEditor(it, true)
             }
         }
     }
 
     override fun modificationCountChanged() {
-        ApplicationManager.getApplication().runReadAction {
+        ApplicationManager.getApplication().invokeLater {
             val editorService = project?.let {
                 if (it.isDisposed) {
                     null
@@ -95,7 +95,7 @@ class EditorToolbarDecorator(
             editorService?.removeDialectForSelectedEditor()
 
             toolbar?.let {
-                editorService?.toggleToolbarForSelectedEditor(it, false)
+                editorService?.toggleToolbarForSelectedEditor(it, true)
             }
         }
     }

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/EditorToolbarDecorator.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/EditorToolbarDecorator.kt
@@ -68,31 +68,35 @@ class EditorToolbarDecorator(
     }
 
     override fun selectionChanged(event: FileEditorManagerEvent) {
-        val editorService = project?.let {
-            if (it.isDisposed) {
-                null
-            } else {
-                it.getEditorService()
+        ApplicationManager.getApplication().runReadAction {
+            val editorService = project?.let {
+                if (it.isDisposed) {
+                    null
+                } else {
+                    it.getEditorService()
+                }
             }
-        }
 
-        toolbar?.let {
-            editorService?.toggleToolbarForSelectedEditor(it, true)
+            toolbar?.let {
+                editorService?.toggleToolbarForSelectedEditor(it, false)
+            }
         }
     }
 
     override fun modificationCountChanged() {
-        val editorService = project?.let {
-            if (it.isDisposed) {
-                null
-            } else {
-                it.getEditorService()
+        ApplicationManager.getApplication().runReadAction {
+            val editorService = project?.let {
+                if (it.isDisposed) {
+                    null
+                } else {
+                    it.getEditorService()
+                }
             }
-        }
-        editorService?.removeDialectForSelectedEditor()
+            editorService?.removeDialectForSelectedEditor()
 
-        toolbar?.let {
-            editorService?.toggleToolbarForSelectedEditor(it, true)
+            toolbar?.let {
+                editorService?.toggleToolbarForSelectedEditor(it, false)
+            }
         }
     }
 

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/EditorToolbarDecorator.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/EditorToolbarDecorator.kt
@@ -5,15 +5,14 @@ import com.intellij.database.dataSource.LocalDataSource
 import com.intellij.database.model.RawDataSource
 import com.intellij.database.psi.DataSourceManager
 import com.intellij.database.run.ConsoleRunConfiguration
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileEditor.FileEditorManagerEvent
 import com.intellij.openapi.fileEditor.FileEditorManagerListener
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
 import com.intellij.psi.util.PsiModificationTracker
 import com.mongodb.jbplugin.editor.models.getToolbarModel
+import com.mongodb.jbplugin.editor.models.maybeGetToolbarModel
 import com.mongodb.jbplugin.editor.services.MdbPluginDisposable
-import com.mongodb.jbplugin.editor.services.implementations.getEditorService
 import kotlinx.coroutines.CoroutineScope
 import org.jetbrains.annotations.TestOnly
 
@@ -52,103 +51,43 @@ class EditorToolbarDecorator(
     // execute can get called multiple times during an IntelliJ session which is why
     // we override the stored project and toolbar everytime it is called
     override suspend fun execute(project: Project) {
-        ApplicationManager.getApplication().runReadAction {
-            val editorService = project.getEditorService()
+        this.project = project
+        project.getToolbarModel().setupEventsSubscription()
+        this.setupSubscriptionsForProject(project)
 
-            this.project = project
-            this.setupSubscriptionsForProject(project)
+        this.toolbar = MdbJavaEditorToolbar(
+            project = project,
+            coroutineScope = coroutineScope,
+        )
 
-            this.toolbar = MdbJavaEditorToolbar(
-                project = project,
-                coroutineScope = coroutineScope,
-            )
-
-            editorService.toggleToolbarForSelectedEditor(this.toolbar!!, false)
-        }
+        project.maybeGetToolbarModel()?.projectExecuted(this.toolbar!!)
     }
 
     override fun selectionChanged(event: FileEditorManagerEvent) {
-        ApplicationManager.getApplication().invokeLater {
-            val editorService = project?.let {
-                if (it.isDisposed) {
-                    null
-                } else {
-                    it.getEditorService()
-                }
-            }
-
-            toolbar?.let {
-                editorService?.toggleToolbarForSelectedEditor(it, true)
-            }
-        }
+        project?.maybeGetToolbarModel()?.selectionChanged(this.toolbar!!)
     }
 
     override fun modificationCountChanged() {
-        ApplicationManager.getApplication().invokeLater {
-            val editorService = project?.let {
-                if (it.isDisposed) {
-                    null
-                } else {
-                    it.getEditorService()
-                }
-            }
-            editorService?.removeDialectForSelectedEditor()
-
-            toolbar?.let {
-                editorService?.toggleToolbarForSelectedEditor(it, true)
-            }
-        }
+        project?.maybeGetToolbarModel()?.modificationCountChanged(this.toolbar!!)
     }
 
     override fun <T : RawDataSource?> dataSourceAdded(manager: DataSourceManager<T>, dataSource: T & Any) {
         // An added DataSource can't possibly change the selection state hence just reloading the DataSources
-        val toolbarModel = project?.let {
-            if (it.isDisposed) {
-                null
-            } else {
-                it.getToolbarModel()
-            }
-        }
-
-        toolbarModel?.dataSourcesChanged()
+        project?.maybeGetToolbarModel()?.dataSourcesChanged()
     }
 
     override fun <T : RawDataSource?> dataSourceRemoved(manager: DataSourceManager<T>, dataSource: T & Any) {
         // A removed DataSource might be our selected one so we first remove it and then reload the DataSources
         // Unselection when happened is expected to trigger state change listener so that will update
         // also the attached resources to the selected editor and the stored DataSource in ToolbarSettings
-        val toolbarModel = project?.let {
-            if (it.isDisposed) {
-                null
-            } else {
-                it.getToolbarModel()
-            }
-        }
-
-        toolbarModel?.dataSourceRemoved(dataSource as LocalDataSource)
+        project?.maybeGetToolbarModel()?.dataSourceRemoved(dataSource as LocalDataSource)
     }
 
     override fun <T : RawDataSource?> dataSourceChanged(manager: DataSourceManager<T>?, dataSource: T?) {
-        val toolbarModel = project?.let {
-            if (it.isDisposed) {
-                null
-            } else {
-                it.getToolbarModel()
-            }
-        }
-
-        toolbarModel?.dataSourcesChanged()
+        project?.maybeGetToolbarModel()?.dataSourcesChanged()
     }
 
     override fun onTerminated(dataSource: LocalDataSource, configuration: ConsoleRunConfiguration?) {
-        val toolbarModel = project?.let {
-            if (it.isDisposed) {
-                null
-            } else {
-                it.getToolbarModel()
-            }
-        }
-
-        toolbarModel?.dataSourceTerminated(dataSource)
+        project?.maybeGetToolbarModel()?.dataSourceTerminated(dataSource)
     }
 }

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/MdbJavaEditorToolbar.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/MdbJavaEditorToolbar.kt
@@ -6,7 +6,6 @@
 package com.mongodb.jbplugin.editor
 
 import com.intellij.database.dataSource.LocalDataSource
-import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.ex.EditorEx
 import com.intellij.openapi.project.Project
@@ -32,23 +31,6 @@ import org.jetbrains.annotations.Nls
 import java.awt.BorderLayout
 import java.awt.event.ActionEvent
 import javax.swing.*
-
-private val log = logger<MdbJavaEditorToolbar>()
-
-/**
- * Data class to encapsulate the current state of the Toolbar
- *
- * @property dataSources
- * @property selectedDataSource
- * @property databases
- * @property selectedDatabase
- */
-data class ToolbarState(
-    val dataSources: List<LocalDataSource>,
-    val selectedDataSource: LocalDataSource?,
-    val databases: List<String>,
-    val selectedDatabase: String?,
-)
 
 /**
  * Toolbar class that encapsulates rendering and interacting with the toolbar itself
@@ -109,7 +91,7 @@ class MdbJavaEditorToolbar(
     }
 
     fun attachToEditor(editor: Editor, showDatabaseComboBox: Boolean) {
-        project.getToolbarModel().initialise()
+        project.getToolbarModel().loadInitialData()
         dataSourceComboBox.attachToParent()
         if (showDatabaseComboBox) {
             showDatabasesComboBox()
@@ -128,7 +110,7 @@ class MdbJavaEditorToolbar(
     }
 
     fun attachToParent(parent: JComponent, showDatabaseComboBox: Boolean) {
-        project.getToolbarModel().initialise()
+        project.getToolbarModel().loadInitialData()
         dataSourceComboBox.attachToParent()
         if (showDatabaseComboBox) {
             showDatabasesComboBox()

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/editor/EditorToolbarDecoratorTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/editor/EditorToolbarDecoratorTest.kt
@@ -91,9 +91,9 @@ class EditorToolbarDecoratorTest {
             runCurrent()
 
             // First from execute but with false as applyReadAction and second from modificationCountChanged
-            verify(editorService, times(2)).toggleToolbarForSelectedEditor(
+            verify(editorService, times(1)).toggleToolbarForSelectedEditor(
                 decorator.getToolbarForTests()!!,
-                false
+                true,
             )
         }
     }
@@ -112,9 +112,9 @@ class EditorToolbarDecoratorTest {
             runCurrent()
 
             // First from execute but with false as applyReadAction and second from modificationCountChanged
-            verify(editorService, times(2)).toggleToolbarForSelectedEditor(
+            verify(editorService, times(1)).toggleToolbarForSelectedEditor(
                 decorator.getToolbarForTests()!!,
-                false
+                true,
             )
         }
     }

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/editor/EditorToolbarDecoratorTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/editor/EditorToolbarDecoratorTest.kt
@@ -91,7 +91,7 @@ class EditorToolbarDecoratorTest {
             runCurrent()
 
             // First from execute but with false as applyReadAction and second from modificationCountChanged
-            verify(editorService, times(1)).toggleToolbarForSelectedEditor(
+            verify(editorService, times(2)).toggleToolbarForSelectedEditor(
                 decorator.getToolbarForTests()!!,
                 false
             )
@@ -112,7 +112,7 @@ class EditorToolbarDecoratorTest {
             runCurrent()
 
             // First from execute but with false as applyReadAction and second from modificationCountChanged
-            verify(editorService, times(1)).toggleToolbarForSelectedEditor(
+            verify(editorService, times(2)).toggleToolbarForSelectedEditor(
                 decorator.getToolbarForTests()!!,
                 false
             )

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/editor/EditorToolbarDecoratorTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/editor/EditorToolbarDecoratorTest.kt
@@ -4,6 +4,7 @@ import com.intellij.database.dataSource.LocalDataSource
 import com.intellij.database.dataSource.LocalDataSourceManager
 import com.intellij.openapi.fileEditor.FileEditorManagerEvent
 import com.intellij.openapi.project.Project
+import com.mongodb.jbplugin.editor.models.ToolbarModel
 import com.mongodb.jbplugin.editor.models.getToolbarModel
 import com.mongodb.jbplugin.editor.services.MdbPluginDisposable
 import com.mongodb.jbplugin.editor.services.implementations.MdbDataSourceService
@@ -62,16 +63,15 @@ class EditorToolbarDecoratorTest {
         }
 
         @Test
-        fun `toggles toolbar using EditorService`(project: Project) = runTest {
+        fun `toggles toolbar using ToolbarModel`(project: Project) = runTest {
             val decorator = spy(EditorToolbarDecorator(TestScope()))
-            val editorService = mock<MdbEditorService>()
-            project.withMockedService(editorService)
+            val toolbarModel = mock<ToolbarModel>()
+            project.withMockedService(toolbarModel)
             decorator.execute(project)
             runCurrent()
 
-            verify(editorService, times(1)).toggleToolbarForSelectedEditor(
+            verify(toolbarModel, times(1)).projectExecuted(
                 decorator.getToolbarForTests()!!,
-                false
             )
         }
     }
@@ -80,10 +80,10 @@ class EditorToolbarDecoratorTest {
     @DisplayName("when selectionChanged is triggered")
     inner class EditorToolbarDecoratorSelectionChanged {
         @Test
-        fun `toggles toolbar using EditorService`(project: Project) = runTest {
+        fun `toggles toolbar using ToolbarModel`(project: Project) = runTest {
             val decorator = spy(EditorToolbarDecorator(TestScope()))
-            val editorService = mock<MdbEditorService>()
-            project.withMockedService(editorService)
+            val toolbarModel = mock<ToolbarModel>()
+            project.withMockedService(toolbarModel)
             decorator.execute(project)
 
             val changeEvent = mock<FileEditorManagerEvent>()
@@ -91,9 +91,8 @@ class EditorToolbarDecoratorTest {
             runCurrent()
 
             // First from execute but with false as applyReadAction and second from modificationCountChanged
-            verify(editorService, times(1)).toggleToolbarForSelectedEditor(
+            verify(toolbarModel, times(1)).selectionChanged(
                 decorator.getToolbarForTests()!!,
-                true,
             )
         }
     }
@@ -102,19 +101,18 @@ class EditorToolbarDecoratorTest {
     @DisplayName("when modificationCountChanged is triggered")
     inner class EditorToolbarDecoratorModificationCountChanged {
         @Test
-        fun `toggles toolbar using EditorService`(project: Project) = runTest {
+        fun `toggles toolbar using ToolbarModel`(project: Project) = runTest {
             val decorator = spy(EditorToolbarDecorator(TestScope()))
-            val editorService = mock<MdbEditorService>()
-            project.withMockedService(editorService)
+            val toolbarModel = mock<ToolbarModel>()
+            project.withMockedService(toolbarModel)
             decorator.execute(project)
 
             decorator.modificationCountChanged()
             runCurrent()
 
             // First from execute but with false as applyReadAction and second from modificationCountChanged
-            verify(editorService, times(1)).toggleToolbarForSelectedEditor(
+            verify(toolbarModel, times(1)).modificationCountChanged(
                 decorator.getToolbarForTests()!!,
-                true,
             )
         }
     }

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/editor/EditorToolbarDecoratorTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/editor/EditorToolbarDecoratorTest.kt
@@ -93,7 +93,7 @@ class EditorToolbarDecoratorTest {
             // First from execute but with false as applyReadAction and second from modificationCountChanged
             verify(editorService, times(1)).toggleToolbarForSelectedEditor(
                 decorator.getToolbarForTests()!!,
-                true
+                false
             )
         }
     }
@@ -114,7 +114,7 @@ class EditorToolbarDecoratorTest {
             // First from execute but with false as applyReadAction and second from modificationCountChanged
             verify(editorService, times(1)).toggleToolbarForSelectedEditor(
                 decorator.getToolbarForTests()!!,
-                true
+                false
             )
         }
     }

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/editor/EditorToolbarDecoratorTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/editor/EditorToolbarDecoratorTest.kt
@@ -132,7 +132,7 @@ class EditorToolbarDecoratorTest {
             project.withMockedService(dataSourceService)
 
             // initialise the toolbar model
-            project.getToolbarModel().initialise()
+            project.getToolbarModel().setupEventsSubscription()
 
             // Mocks for our assertions
             val dataSource = mock<LocalDataSource>()
@@ -170,7 +170,7 @@ class EditorToolbarDecoratorTest {
             project.withMockedService(dataSourceService)
 
             // initialise the toolbar model
-            project.getToolbarModel().initialise()
+            project.getToolbarModel().setupEventsSubscription()
 
             // Mocks for our assertions
             val existingDataSource = mock<LocalDataSource>()
@@ -220,7 +220,7 @@ class EditorToolbarDecoratorTest {
             project.withMockedService(dataSourceService)
 
             // initialise the toolbar model
-            project.getToolbarModel().initialise()
+            project.getToolbarModel().setupEventsSubscription()
 
             // Mocks for our assertions
             // Both instances are for same DataSource
@@ -263,7 +263,7 @@ class EditorToolbarDecoratorTest {
             project.withMockedService(dataSourceService)
 
             // initialise ToolbarModel
-            project.getToolbarModel().initialise()
+            project.getToolbarModel().setupEventsSubscription()
 
             // Mocks for our assertions
             // Both instances are for same DataSource
@@ -323,7 +323,7 @@ class EditorToolbarDecoratorTest {
             project.withMockedService(editorService)
             project.withMockedService(dataSourceService)
 
-            project.getToolbarModel().initialise()
+            project.getToolbarModel().setupEventsSubscription()
 
             // Mocks for our assertions
             val dataSource = mock<LocalDataSource>()
@@ -358,7 +358,7 @@ class EditorToolbarDecoratorTest {
             project.withMockedService(editorService)
             project.withMockedService(dataSourceService)
 
-            project.getToolbarModel().initialise()
+            project.getToolbarModel().setupEventsSubscription()
 
             // Mocks for our assertions
             val dataSource = mock<LocalDataSource>()
@@ -404,7 +404,7 @@ class EditorToolbarDecoratorTest {
             project.withMockedService(editorService)
             project.withMockedService(dataSourceService)
 
-            project.getToolbarModel().initialise()
+            project.getToolbarModel().setupEventsSubscription()
 
             // Mocks for our assertions
             val dataSource = mock<LocalDataSource>()
@@ -438,7 +438,7 @@ class EditorToolbarDecoratorTest {
             project.withMockedService(editorService)
             project.withMockedService(dataSourceService)
 
-            project.getToolbarModel().initialise()
+            project.getToolbarModel().setupEventsSubscription()
 
             // Mocks for our assertions
             val dataSource = mock<LocalDataSource>()

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/editor/models/ToolbarModelTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/editor/models/ToolbarModelTest.kt
@@ -60,14 +60,15 @@ class ToolbarModelTest {
     }
 
     @Nested
-    @DisplayName("when initialised")
-    inner class ToolbarModelInitialised {
+    @DisplayName("when initial data is loaded")
+    inner class ToolbarModelInitialDataLoaded {
         @Test
         fun `restores last selected dataSource and initiate a connection attempt`() {
             `when`(toolbarSettings.dataSourceId).thenReturn("mocked-data-source-unique-id")
             `when`(dataSourceService.listMongoDbDataSources()).thenReturn(listOf(dataSource))
 
-            toolbarModel.initialise()
+            toolbarModel.setupEventsSubscription()
+            toolbarModel.loadInitialData()
             eventually {
                 val toolbarState = toolbarModel.toolbarState.value
                 assertEquals(
@@ -82,7 +83,8 @@ class ToolbarModelTest {
         fun `will not attempt to detach the datasource and database from Editor for restored selection`() {
             `when`(toolbarSettings.dataSourceId).thenReturn("mocked-data-source-unique-id")
             `when`(dataSourceService.listMongoDbDataSources()).thenReturn(listOf(dataSource))
-            toolbarModel.initialise()
+            toolbarModel.setupEventsSubscription()
+            toolbarModel.loadInitialData()
 
             // Wait for state update
             eventually {
@@ -101,7 +103,8 @@ class ToolbarModelTest {
             `when`(toolbarSettings.dataSourceId).thenReturn("mocked-data-source-unique-id")
             `when`(dataSourceService.listMongoDbDataSources()).thenReturn(emptyList())
 
-            toolbarModel.initialise()
+            toolbarModel.setupEventsSubscription()
+            toolbarModel.loadInitialData()
             val newToolbarState = toolbarModel.toolbarState.value
             assertNull(newToolbarState.selectedDataSource)
         }
@@ -113,7 +116,7 @@ class ToolbarModelTest {
         @Test
         fun `should update the state with the selected data source and start connecting`() {
             `when`(dataSourceService.listMongoDbDataSources()).thenReturn(listOf(dataSource))
-            toolbarModel.initialise()
+            toolbarModel.setupEventsSubscription()
             toolbarModel.selectDataSource(dataSource)
             eventually {
                 val toolbarState = toolbarModel.toolbarState.value
@@ -137,7 +140,8 @@ class ToolbarModelTest {
             `when`(
                 dataSourceService.listMongoDbDataSources()
             ).thenReturn(listOf(dataSource, previousDataSource))
-            toolbarModel.initialise()
+            toolbarModel.setupEventsSubscription()
+            toolbarModel.loadInitialData()
             // restore to take effect
             eventually {
                 val toolbarState = toolbarModel.toolbarState.value
@@ -159,7 +163,7 @@ class ToolbarModelTest {
         @Test
         fun `when connection starts, it should update the state`() = runBlocking {
             `when`(dataSourceService.listMongoDbDataSources()).thenReturn(listOf(dataSource))
-            toolbarModel.initialise()
+            toolbarModel.setupEventsSubscription()
             toolbarModel.selectDataSource(dataSource)
             eventually {
                 val toolbarState = toolbarModel.toolbarState.value
@@ -178,7 +182,7 @@ class ToolbarModelTest {
         @Test
         fun `when connection is successful, it should update the state`() = runBlocking {
             `when`(dataSourceService.listMongoDbDataSources()).thenReturn(listOf(dataSource))
-            toolbarModel.initialise()
+            toolbarModel.setupEventsSubscription()
             toolbarModel.selectDataSource(dataSource)
             eventually {
                 val toolbarState = toolbarModel.toolbarState.value
@@ -204,7 +208,7 @@ class ToolbarModelTest {
         @Test
         fun `when connection is successful, it should update ToolbarSettings, EditorService and also start loading databases`() = runBlocking {
             `when`(dataSourceService.listMongoDbDataSources()).thenReturn(listOf(dataSource))
-            toolbarModel.initialise()
+            toolbarModel.setupEventsSubscription()
             toolbarModel.selectDataSource(dataSource)
             eventually {
                 val toolbarState = toolbarModel.toolbarState.value
@@ -235,7 +239,7 @@ class ToolbarModelTest {
         @Test
         fun `when connection is unsuccessful, it should revert the selection, update the state, ToolbarSettings and EditorService`() = runBlocking {
             `when`(dataSourceService.listMongoDbDataSources()).thenReturn(listOf(dataSource))
-            toolbarModel.initialise()
+            toolbarModel.setupEventsSubscription()
             toolbarModel.selectDataSource(dataSource)
             eventually {
                 val toolbarState = toolbarModel.toolbarState.value
@@ -264,7 +268,7 @@ class ToolbarModelTest {
         @Test
         fun `when connection is failed, it should update the state`() = runBlocking {
             `when`(dataSourceService.listMongoDbDataSources()).thenReturn(listOf(dataSource))
-            toolbarModel.initialise()
+            toolbarModel.setupEventsSubscription()
             toolbarModel.selectDataSource(dataSource)
             eventually {
                 val toolbarState = toolbarModel.toolbarState.value
@@ -286,7 +290,7 @@ class ToolbarModelTest {
         @Test
         fun `when databases loading starts, it updates the state`() = runBlocking {
             `when`(dataSourceService.listMongoDbDataSources()).thenReturn(listOf(dataSource))
-            toolbarModel.initialise()
+            toolbarModel.setupEventsSubscription()
             toolbarModel.selectDataSource(dataSource)
             eventually {
                 val toolbarState = toolbarModel.toolbarState.value
@@ -319,7 +323,7 @@ class ToolbarModelTest {
         @Test
         fun `when databases loading failed, it updates the state`() = runBlocking {
             `when`(dataSourceService.listMongoDbDataSources()).thenReturn(listOf(dataSource))
-            toolbarModel.initialise()
+            toolbarModel.setupEventsSubscription()
             toolbarModel.selectDataSource(dataSource)
             eventually {
                 val toolbarState = toolbarModel.toolbarState.value
@@ -360,7 +364,7 @@ class ToolbarModelTest {
         @Test
         fun `when databases loading is successful, it updates the state`() = runBlocking {
             `when`(dataSourceService.listMongoDbDataSources()).thenReturn(listOf(dataSource))
-            toolbarModel.initialise()
+            toolbarModel.setupEventsSubscription()
             toolbarModel.selectDataSource(dataSource)
             eventually {
                 val toolbarState = toolbarModel.toolbarState.value
@@ -402,7 +406,7 @@ class ToolbarModelTest {
         @Test
         fun `when databases loading is successful, it restores the previous selection if it is present in databases list`() = runBlocking {
             `when`(dataSourceService.listMongoDbDataSources()).thenReturn(listOf(dataSource))
-            toolbarModel.initialise()
+            toolbarModel.setupEventsSubscription()
             toolbarModel.selectDataSource(dataSource)
             eventually {
                 val toolbarState = toolbarModel.toolbarState.value
@@ -449,7 +453,7 @@ class ToolbarModelTest {
         @Test
         fun `when databases loading is successful, it will not restore the previous selection if it is not present in databases list`() = runBlocking {
             `when`(dataSourceService.listMongoDbDataSources()).thenReturn(listOf(dataSource))
-            toolbarModel.initialise()
+            toolbarModel.setupEventsSubscription()
             toolbarModel.selectDataSource(dataSource)
             eventually {
                 val toolbarState = toolbarModel.toolbarState.value
@@ -492,7 +496,7 @@ class ToolbarModelTest {
         @Test
         fun `when databases loading is successful and the database was never selected, it will select the inferred database from editor service`() = runBlocking {
             `when`(dataSourceService.listMongoDbDataSources()).thenReturn(listOf(dataSource))
-            toolbarModel.initialise()
+            toolbarModel.setupEventsSubscription()
             toolbarModel.selectDataSource(dataSource)
             eventually {
                 val toolbarState = toolbarModel.toolbarState.value
@@ -544,7 +548,7 @@ class ToolbarModelTest {
         @Test
         fun `should update the state with the unselected data source and reset the dependent state`() = runBlocking {
             `when`(dataSourceService.listMongoDbDataSources()).thenReturn(listOf(dataSource))
-            toolbarModel.initialise()
+            toolbarModel.setupEventsSubscription()
             toolbarModel.selectDataSource(dataSource)
             eventually {
                 val toolbarState = toolbarModel.toolbarState.value
@@ -577,7 +581,7 @@ class ToolbarModelTest {
         @Test
         fun `should update the state with the unselected data source and reset the dependent state`() = runBlocking {
             `when`(dataSourceService.listMongoDbDataSources()).thenReturn(listOf(dataSource))
-            toolbarModel.initialise()
+            toolbarModel.setupEventsSubscription()
             toolbarModel.selectDataSource(dataSource)
             eventually {
                 val toolbarState = toolbarModel.toolbarState.value
@@ -610,7 +614,7 @@ class ToolbarModelTest {
         @Test
         fun `should update the state with the unselected data source and reset the dependent state`() = runBlocking {
             `when`(dataSourceService.listMongoDbDataSources()).thenReturn(listOf(dataSource))
-            toolbarModel.initialise()
+            toolbarModel.setupEventsSubscription()
             toolbarModel.selectDataSource(dataSource)
             eventually {
                 val toolbarState = toolbarModel.toolbarState.value
@@ -643,7 +647,7 @@ class ToolbarModelTest {
         @Test
         fun `should update the state with the updated data source`() {
             `when`(dataSourceService.listMongoDbDataSources()).thenReturn(listOf(dataSource))
-            toolbarModel.initialise()
+            toolbarModel.setupEventsSubscription()
             toolbarModel.selectDataSource(dataSource)
             eventually {
                 val toolbarState = toolbarModel.toolbarState.value
@@ -668,7 +672,7 @@ class ToolbarModelTest {
         @Test
         fun `should update the state with the selected database`() = runBlocking {
             `when`(dataSourceService.listMongoDbDataSources()).thenReturn(listOf(dataSource))
-            toolbarModel.initialise()
+            toolbarModel.setupEventsSubscription()
             toolbarModel.selectDataSource(dataSource)
             eventually {
                 val toolbarState = toolbarModel.toolbarState.value
@@ -719,7 +723,7 @@ class ToolbarModelTest {
         @Test
         fun `should update the state with the unselected database`() = runBlocking {
             `when`(dataSourceService.listMongoDbDataSources()).thenReturn(listOf(dataSource))
-            toolbarModel.initialise()
+            toolbarModel.setupEventsSubscription()
             toolbarModel.selectDataSource(dataSource)
             eventually {
                 val toolbarState = toolbarModel.toolbarState.value

--- a/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParser.kt
+++ b/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParser.kt
@@ -200,7 +200,7 @@ object JavaDriverDialectParser : DialectParser<PsiElement> {
                 ),
             )
         } else if (method.isVarArgs || method.name == "not") {
-// Filters.and, Filters.or... are varargs
+            // Filters.and, Filters.or... are varargs
             return Node(
                 filter,
                 listOf(
@@ -211,6 +211,22 @@ object JavaDriverDialectParser : DialectParser<PsiElement> {
                             .mapNotNull { parseFilterExpression(it) },
                     ),
                 ),
+            )
+        } else if (method.name == "eq" && method.parameters.size == 1) {
+            if (filter.argumentList.expressionCount == 0) {
+                return null
+            }
+            val valueExpression = filter.argumentList.expressions[0]
+            val valueReference = resolveValueFromExpression(valueExpression)
+            val fieldReference = HasFieldReference.Known(valueExpression, "_id")
+
+            return Node(
+                filter,
+                listOf(
+                    Named(Name.from(method.name)),
+                    HasFieldReference(fieldReference),
+                    HasValueReference(valueReference),
+                )
             )
         } else if (method.parameters.size == 2) {
             // If it has two parameters, it's field/value.
@@ -230,7 +246,7 @@ object JavaDriverDialectParser : DialectParser<PsiElement> {
                 ),
             )
         }
-// here we really don't know much, so just don't attempt to parse the query
+        // here we really don't know much, so just don't attempt to parse the query
         return null
     }
 
@@ -297,7 +313,7 @@ object JavaDriverDialectParser : DialectParser<PsiElement> {
     private fun parseUpdatesExpression(filter: PsiMethodCallExpression): Node<PsiElement>? {
         val method = filter.resolveMethod() ?: return null
         if (method.isVarArgs) {
-// Updates.combine
+            // Updates.combine
             return Node(
                 filter,
                 listOf(
@@ -310,7 +326,7 @@ object JavaDriverDialectParser : DialectParser<PsiElement> {
                 ),
             )
         } else if (method.parameters.size == 2) {
-// If it has two parameters, it's field/value.
+            // If it has two parameters, it's field/value.
             val fieldReference = resolveFieldNameFromExpression(filter.argumentList.expressions[0])
             val valueReference = resolveValueFromExpression(filter.argumentList.expressions[1])
 
@@ -327,7 +343,7 @@ object JavaDriverDialectParser : DialectParser<PsiElement> {
                 ),
             )
         } else if (method.parameters.size == 1) {
-// Updates.unset for example
+            // Updates.unset for example
             val fieldReference = resolveFieldNameFromExpression(filter.argumentList.expressions[0])
 
             return Node(
@@ -340,7 +356,7 @@ object JavaDriverDialectParser : DialectParser<PsiElement> {
                 ),
             )
         }
-// here we really don't know much, so just don't attempt to parse the query
+        // here we really don't know much, so just don't attempt to parse the query
         return null
     }
 
@@ -442,7 +458,7 @@ fun PsiType.isJavaIterable(): Boolean {
             }
     }
 
-    return return recursivelyCheckIsIterable(this)
+    return recursivelyCheckIsIterable(this)
 }
 
 fun PsiType.guessIterableContentType(project: Project): BsonType {


### PR DESCRIPTION
There is another variant of Filters.eq which only accepts single parameter. In that case, the FieldReference is static and pointing to _id. This commit adds support for parsing this variant.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER-IF-ANY>

  eg. fix(type-hint): infer type of a constant for type checking INTELLIJ-1111
-->

## Description

<!--- Describe your changes in detail so reviewers have enough content on what this PR aims to achieve -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist

- [ ] New tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
- [ ] Changelog is updated accordingly.
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement).

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->