### PR TITLE
poc(parser): parser combinator poc

### DIFF
--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/impl/JavaDriverFieldCheckLinterInspectionTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/impl/JavaDriverFieldCheckLinterInspectionTest.kt
@@ -16,7 +16,6 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 
 @CodeInsightTest
-@Suppress("TOO_LONG_FUNCTION", "LONG_LINE")
 class JavaDriverFieldCheckLinterInspectionTest {
     @ParsingTest(
         fileName = "Repository.java",
@@ -86,7 +85,9 @@ public class Repository {
         `when`(
             readModelProvider.slice(eq(dataSource), any<GetCollectionSchema.Slice>())
         ).thenReturn(
-            GetCollectionSchema(CollectionSchema(Namespace("", ""), BsonObject(emptyMap()))),
+            GetCollectionSchema(
+                CollectionSchema(Namespace("myDatabase", "myCollection"), BsonObject(emptyMap()))
+            ),
         )
 
         fixture.enableInspections(FieldCheckInspectionBridge::class.java)
@@ -129,7 +130,7 @@ public class Repository {
         ).thenReturn(
             GetCollectionSchema(
                 CollectionSchema(
-                    Namespace("", ""),
+                    Namespace("myDatabase", "myCollection"),
                     BsonObject(mapOf("thisIsDouble" to BsonDouble))
                 )
             ),

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/impl/SpringCriteriaFieldCheckLinterInspectionTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/impl/SpringCriteriaFieldCheckLinterInspectionTest.kt
@@ -124,7 +124,9 @@ class BookRepository {
         `when`(
             readModelProvider.slice(eq(dataSource), any<GetCollectionSchema.Slice>())
         ).thenReturn(
-            GetCollectionSchema(CollectionSchema(Namespace("", ""), BsonObject(emptyMap()))),
+            GetCollectionSchema(
+                CollectionSchema(Namespace("sample_mflix", "book"), BsonObject(emptyMap()))
+            ),
         )
 
         application.withMockedService(dbConnectionManager)
@@ -203,7 +205,9 @@ class BookRepository {
         `when`(
             readModelProvider.slice(eq(dataSource), any<GetCollectionSchema.Slice>())
         ).thenReturn(
-            GetCollectionSchema(CollectionSchema(Namespace("", ""), BsonObject(emptyMap()))),
+            GetCollectionSchema(
+                CollectionSchema(Namespace("bad_db", "book"), BsonObject(emptyMap()))
+            ),
         )
 
         application.withMockedService(dbConnectionManager)

--- a/packages/mongodb-linting-engine/src/main/kotlin/com/mongodb/jbplugin/linting/FieldCheckingLinter.kt
+++ b/packages/mongodb-linting-engine/src/main/kotlin/com/mongodb/jbplugin/linting/FieldCheckingLinter.kt
@@ -150,7 +150,7 @@ object FieldCheckingLinter {
     ): FieldCheckWarning<S>? {
         val fieldType = collectionSchema.typeOf(pair.first.fieldName)
         val fieldName = pair.first.fieldName
-        val valueSource = pair.first.source
+        val valueSource = pair.second.first
         val valueType = pair.second.second
 
         return FieldCheckWarning.FieldValueTypeMismatch(

--- a/packages/mongodb-linting-engine/src/main/kotlin/com/mongodb/jbplugin/linting/FieldCheckingLinter.kt
+++ b/packages/mongodb-linting-engine/src/main/kotlin/com/mongodb/jbplugin/linting/FieldCheckingLinter.kt
@@ -24,7 +24,7 @@ import com.mongodb.jbplugin.mql.parser.first
 import com.mongodb.jbplugin.mql.parser.map
 import com.mongodb.jbplugin.mql.parser.mapError
 import com.mongodb.jbplugin.mql.parser.mapMany
-import com.mongodb.jbplugin.mql.parser.run
+import com.mongodb.jbplugin.mql.parser.parse
 import com.mongodb.jbplugin.mql.parser.zip
 
 /**
@@ -95,7 +95,7 @@ object FieldCheckingLinter {
                     dataSource,
                     GetCollectionSchema.Slice(it.namespace)
                 ).schema
-            }.run(query)
+            }.parse(query)
 
         return FieldCheckResult(
             when (querySchema) {
@@ -118,7 +118,7 @@ object FieldCheckingLinter {
                         )
                     )
 
-                    val parsingResult = allFieldAndValueReferencesParser.run(query)
+                    val parsingResult = allFieldAndValueReferencesParser.parse(query)
                     parsingResult.orElse { emptyList() }.filterNotNull()
                 }
             }

--- a/packages/mongodb-linting-engine/src/main/kotlin/com/mongodb/jbplugin/linting/FieldCheckingLinter.kt
+++ b/packages/mongodb-linting-engine/src/main/kotlin/com/mongodb/jbplugin/linting/FieldCheckingLinter.kt
@@ -6,16 +6,26 @@ package com.mongodb.jbplugin.linting
 
 import com.mongodb.jbplugin.accessadapter.MongoDbReadModelProvider
 import com.mongodb.jbplugin.accessadapter.slice.GetCollectionSchema
-import com.mongodb.jbplugin.linting.FieldCheckWarning.FieldDoesNotExist
-import com.mongodb.jbplugin.mql.*
-import com.mongodb.jbplugin.mql.components.HasCollectionReference
+import com.mongodb.jbplugin.mql.BsonNull
+import com.mongodb.jbplugin.mql.BsonType
+import com.mongodb.jbplugin.mql.CollectionSchema
+import com.mongodb.jbplugin.mql.Namespace
+import com.mongodb.jbplugin.mql.Node
+import com.mongodb.jbplugin.mql.adt.Either
 import com.mongodb.jbplugin.mql.components.HasFieldReference
-import com.mongodb.jbplugin.mql.components.HasFilter
-import com.mongodb.jbplugin.mql.components.HasValueReference
-
-private typealias FieldCheckWarnings<S> = List<FieldCheckWarning<S>>
-
-private typealias FieldAndValueReferences<S> = List<Reference<S>>
+import com.mongodb.jbplugin.mql.parser.components.NoFieldReference
+import com.mongodb.jbplugin.mql.parser.components.allFiltersRecursively
+import com.mongodb.jbplugin.mql.parser.components.constantValueReference
+import com.mongodb.jbplugin.mql.parser.components.knownCollection
+import com.mongodb.jbplugin.mql.parser.components.knownFieldReference
+import com.mongodb.jbplugin.mql.parser.components.runtimeValueReference
+import com.mongodb.jbplugin.mql.parser.filter
+import com.mongodb.jbplugin.mql.parser.first
+import com.mongodb.jbplugin.mql.parser.map
+import com.mongodb.jbplugin.mql.parser.mapError
+import com.mongodb.jbplugin.mql.parser.mapMany
+import com.mongodb.jbplugin.mql.parser.zip
+import kotlinx.coroutines.runBlocking
 
 /**
  * Marker type for the result of the type.
@@ -44,8 +54,7 @@ sealed interface FieldCheckWarning<S> {
      * value does not match the BsonType of inspected field
      *
      * @param S
-     * @property valueSource The source providing the field and value
-     * for inspection
+     * @property valueSource The source providing the field and value for inspection
      * @property field Text value of the field being inspected
      * @property fieldType BsonType of inspected field
      * @property valueType BsonType of inspected value
@@ -67,12 +76,8 @@ sealed interface FieldCheckWarning<S> {
  * @property warnings
  */
 data class FieldCheckResult<S>(
-    val warnings: FieldCheckWarnings<S>,
-) {
-    companion object {
-        fun <S> empty(): FieldCheckResult<S> = FieldCheckResult(emptyList())
-    }
-}
+    val warnings: List<FieldCheckWarning<S>>,
+)
 
 /**
  * Linter that verifies that all fields that are referenced in a query do exist in the target collection.
@@ -83,131 +88,76 @@ object FieldCheckingLinter {
         readModelProvider: MongoDbReadModelProvider<D>,
         query: Node<S>,
     ): FieldCheckResult<S> {
-        val queryNamespace =
-            query.component<HasCollectionReference<S>>() ?: return FieldCheckResult.empty()
-        if (queryNamespace.reference !is HasCollectionReference.Known) {
-            return FieldCheckResult.empty()
-        }
+        val warnings = runBlocking {
+            val querySchemaParser = knownCollection<S>()
+                .filter { it.namespace.isValid }
+                .map {
+                    readModelProvider.slice(
+                        dataSource,
+                        GetCollectionSchema.Slice(it.namespace)
+                    ).schema
+                }
 
-        val namespace = (queryNamespace.reference as HasCollectionReference.Known).namespace
-        if (!namespace.isValid) {
-            return FieldCheckResult.empty()
-        }
+            when (val collectionSchemaResult = querySchemaParser(query)) {
+                is Either.Left -> emptyList()
+                is Either.Right -> {
+                    val collectionSchema = collectionSchemaResult.value
+                    val extractFieldExistenceWarning = knownFieldReference<S>()
+                        .map { toFieldNotExistingWarning(collectionSchema, it) }
+                        .mapError { NoFieldReference }
 
-        val collection = readModelProvider.slice(
-            dataSource,
-            GetCollectionSchema.Slice(namespace)
-        ).schema
-        val fieldAndValueRefs = query.getAllFieldAndValueReferences()
+                    val extractValueReferenceParser = first(
+                        runtimeValueReference<S>().map { it.source to it.type },
+                        constantValueReference<S>().map { it.source to it.type }
+                    )
 
-        val warnings =
-            fieldAndValueRefs.mapNotNull {
-                when (it) {
-                    is Reference.FieldReference -> it.toFieldExistenceWarning(collection, namespace)
-                    is Reference.FieldValueReference ->
-                        it.toFieldExistenceWarning(collection, namespace)
-                            ?: it.toFieldValueTypeMismatchWarning(collection)
+                    val extractTypeMismatchWarning = knownFieldReference<S>()
+                        .filter { collectionSchema.typeOf(it.fieldName) != BsonNull }
+                        .zip(extractValueReferenceParser)
+                        .map { toValueMismatchWarning(collectionSchema, it) }
+                        .mapError { NoFieldReference }
+
+                    val allFieldAndValueReferencesParser = allFiltersRecursively<S>().mapMany(
+                        first(
+                            extractTypeMismatchWarning,
+                            extractFieldExistenceWarning
+                        )
+                    )
+
+                    allFieldAndValueReferencesParser(query).orElse { emptyList() }.filterNotNull()
                 }
             }
+        }
 
         return FieldCheckResult(warnings)
     }
-}
 
-/**
- * @param S
- */
-sealed interface Reference<S> {
-    /**
-     * @param S
-     * @property fieldSource
-     * @property fieldName
-     */
-    data class FieldReference<S>(val fieldSource: S, val fieldName: String) : Reference<S> {
-        fun toFieldExistenceWarning(
-            collectionSchema: CollectionSchema,
-            namespace: Namespace,
-        ): FieldCheckWarning.FieldDoesNotExist<S>? {
-            val fieldType = collectionSchema.typeOf(fieldName)
-            return FieldCheckWarning.FieldDoesNotExist(
-                fieldSource,
-                fieldName,
-                namespace
-            ).takeIf { fieldType == BsonNull }
-        }
+    private fun <S> toFieldNotExistingWarning(
+        collectionSchema: CollectionSchema,
+        known: HasFieldReference.Known<S>
+    ): FieldCheckWarning<S>? {
+        val fieldType = collectionSchema.typeOf(known.fieldName)
+        return FieldCheckWarning.FieldDoesNotExist(
+            known.source,
+            known.fieldName,
+            collectionSchema.namespace
+        ).takeIf { fieldType == BsonNull } as? FieldCheckWarning<S>
     }
 
-    /**
-     * @param S
-     * @property fieldSource
-     * @property fieldName
-     * @property valueSource
-     * @property valueType
-     */
-    data class FieldValueReference<S>(
-        val fieldSource: S,
-        val fieldName: String,
-        val valueSource: S,
-        val valueType: BsonType
-    ) : Reference<S> {
-        fun toFieldExistenceWarning(
-            collectionSchema: CollectionSchema,
-            namespace: Namespace,
-        ): FieldCheckWarning.FieldDoesNotExist<S>? {
-            val fieldType = collectionSchema.typeOf(fieldName)
-            return FieldCheckWarning.FieldDoesNotExist(
-                fieldSource,
-                fieldName,
-                namespace
-            ).takeIf { fieldType == BsonNull }
-        }
+    private fun <S> toValueMismatchWarning(
+        collectionSchema: CollectionSchema,
+        pair: Pair<HasFieldReference.Known<S>, Pair<S, BsonType>>
+    ): FieldCheckWarning<S>? {
+        val fieldType = collectionSchema.typeOf(pair.first.fieldName)
+        val fieldName = pair.first.fieldName
+        val valueSource = pair.first.source
+        val valueType = pair.second.second
 
-        fun toFieldValueTypeMismatchWarning(
-            collectionSchema: CollectionSchema,
-        ): FieldCheckWarning.FieldValueTypeMismatch<S>? {
-            val fieldType = collectionSchema.typeOf(fieldName)
-            return FieldCheckWarning.FieldValueTypeMismatch(
-                fieldName,
-                fieldType,
-                valueSource,
-                valueType
-            ).takeIf { !valueType.isAssignableTo(fieldType) }
-        }
-    }
-}
-
-private fun <S> Node<S>.getAllFieldAndValueReferences(): FieldAndValueReferences<S> {
-    val hasFilter = component<HasFilter<S>>()
-    val otherRefs =
-        hasFilter?.children?.flatMap { it.getAllFieldAndValueReferences() } ?: emptyList()
-    val fieldRef = component<HasFieldReference<S>>()?.reference ?: return otherRefs
-    val valueRef = component<HasValueReference<S>>()?.reference
-    return if (fieldRef is HasFieldReference.Known) {
-        otherRefs + (
-            valueRef?.let { reference ->
-                when (reference) {
-                    is HasValueReference.Constant<S> -> Reference.FieldValueReference(
-                        fieldRef.source,
-                        fieldRef.fieldName,
-                        reference.source,
-                        reference.type
-                    )
-
-                    is HasValueReference.Runtime<S> -> Reference.FieldValueReference(
-                        fieldRef.source,
-                        fieldRef.fieldName,
-                        reference.source,
-                        reference.type
-                    )
-
-                    else -> null
-                }
-            } ?: Reference.FieldReference(
-                fieldRef.source,
-                fieldRef.fieldName,
-            )
-            )
-    } else {
-        otherRefs
+        return FieldCheckWarning.FieldValueTypeMismatch(
+            fieldName,
+            fieldType,
+            valueSource,
+            valueType
+        ).takeIf { !valueType.isAssignableTo(fieldType) } as? FieldCheckWarning<S>
     }
 }

--- a/packages/mongodb-linting-engine/src/main/kotlin/com/mongodb/jbplugin/linting/NamespaceCheckingLinter.kt
+++ b/packages/mongodb-linting-engine/src/main/kotlin/com/mongodb/jbplugin/linting/NamespaceCheckingLinter.kt
@@ -8,9 +8,12 @@ package com.mongodb.jbplugin.linting
 import com.mongodb.jbplugin.accessadapter.MongoDbReadModelProvider
 import com.mongodb.jbplugin.accessadapter.slice.ListCollections
 import com.mongodb.jbplugin.accessadapter.slice.ListDatabases
-import com.mongodb.jbplugin.linting.NamespaceCheckWarning.*
+import com.mongodb.jbplugin.linting.NamespaceCheckWarning.CollectionDoesNotExist
+import com.mongodb.jbplugin.linting.NamespaceCheckWarning.DatabaseDoesNotExist
+import com.mongodb.jbplugin.linting.NamespaceCheckWarning.NoNamespaceInferred
 import com.mongodb.jbplugin.mql.Node
-import com.mongodb.jbplugin.mql.components.HasCollectionReference
+import com.mongodb.jbplugin.mql.parser.*
+import com.mongodb.jbplugin.mql.parser.components.knownCollection
 
 /**
  * Marker type for the result of the linter.
@@ -80,45 +83,45 @@ object NamespaceCheckingLinter {
         readModelProvider: MongoDbReadModelProvider<D>,
         query: Node<S>,
     ): NamespaceCheckResult<S> {
-        val collReference =
-            query.component<HasCollectionReference<S>>() ?: return NamespaceCheckResult(
-                listOf(NoNamespaceInferred(query.source))
-            )
+        val dbList = readModelProvider.slice(dataSource, ListDatabases.Slice)
+
+        val databaseDoesNotExistParser = knownCollection<S>()
+            .filter {
+                dbList.databases.find { database -> it.namespace.database == database.name } ==
+                    null
+            }
+            .map {
+                DatabaseDoesNotExist(
+                    source = it.databaseSource!!,
+                    database = it.namespace.database,
+                )
+            }
+
+        val collectionDoesNotExistParser = knownCollection<S>()
+            .filter { ref ->
+                !runCatching {
+                    readModelProvider.slice(
+                        dataSource,
+                        ListCollections.Slice(ref.namespace.database)
+                    ).collections.map { it.name }
+                }.getOrDefault(emptyList())
+                    .contains(ref.namespace.collection)
+            }.map {
+                CollectionDoesNotExist(
+                    source = it.collectionSource!!,
+                    database = it.namespace.database,
+                    collection = it.namespace.collection
+                )
+            }
+
+        val namespaceErrorsParser = first(
+            databaseDoesNotExistParser.map { it as NamespaceCheckWarning<S> }.map(::listOf),
+            collectionDoesNotExistParser.map { it as NamespaceCheckWarning<S> }.map(::listOf),
+            otherwise { listOf(NoNamespaceInferred(query.source)) }
+        )
 
         return NamespaceCheckResult(
-            when (val ref = collReference.reference) {
-                is HasCollectionReference.Known<S> -> {
-                    val dbList = readModelProvider.slice(dataSource, ListDatabases.Slice)
-                    val collList = runCatching {
-                        readModelProvider.slice(
-                            dataSource,
-                            ListCollections.Slice(ref.namespace.database)
-                        )
-                            .collections.map { it.name }
-                    }.getOrDefault(emptyList())
-
-                    if (dbList.databases.find { it.name == ref.namespace.database } == null) {
-                        listOf(
-                            DatabaseDoesNotExist(
-                                source = ref.databaseSource!!,
-                                database = ref.namespace.database,
-                            )
-                        )
-                    } else if (!collList.contains(ref.namespace.collection)) {
-                        listOf(
-                            CollectionDoesNotExist(
-                                source = ref.collectionSource!!,
-                                database = ref.namespace.database,
-                                collection = ref.namespace.collection
-                            )
-                        )
-                    } else {
-                        emptyList()
-                    }
-                }
-
-                else -> listOf(NoNamespaceInferred(query.source))
-            }
+            namespaceErrorsParser.parse(query).orElse { emptyList() }
         )
     }
 }

--- a/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/adt/Either.kt
+++ b/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/adt/Either.kt
@@ -8,4 +8,11 @@ sealed class Either<A, B> {
         fun <A, B> left(a: A): Either<A, B> = Left(a) as Either<A, B>
         fun <A, B> right(a: B): Either<A, B> = Right(a) as Either<A, B>
     }
+
+    fun orElse(defVal: () -> B): B {
+        return when (this) {
+            is Left -> defVal()
+            is Right -> value
+        }
+    }
 }

--- a/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/adt/EitherInclusive.kt
+++ b/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/adt/EitherInclusive.kt
@@ -1,0 +1,3 @@
+package com.mongodb.jbplugin.mql.adt
+
+typealias EitherInclusive<A, B> = Pair<A?, B?>

--- a/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/Parser.kt
+++ b/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/Parser.kt
@@ -73,6 +73,20 @@ fun <I, E, O> Parser<I, E, O>.filter(
 /**
  * Returns a new parser that maps the output to a new type.
  */
+fun <I, E, O> Parser<I, E, O>.anyError(): Parser<I, Any, O> {
+    return this as Parser<I, Any, O>
+}
+
+/**
+ * Returns a new parser that maps the output to a new type.
+ */
+fun <OO, I, E, O> Parser<I, E, O>.castValue(): Parser<I, E, OO> {
+    return this as Parser<I, E, OO>
+}
+
+/**
+ * Returns a new parser that maps the output to a new type.
+ */
 fun <I, E, O, OO> Parser<I, E, O>.map(mapFn: (O) -> OO): Parser<I, E, OO> {
     return { input ->
         when (val result = this(input)) {
@@ -80,6 +94,13 @@ fun <I, E, O, OO> Parser<I, E, O>.map(mapFn: (O) -> OO): Parser<I, E, OO> {
             is Either.Right -> Either.right(mapFn(result.value))
         }
     }
+}
+
+/**
+ * Returns a new parser that maps the output to a new type.
+ */
+inline fun <reified OO, I, E, O> Parser<I, E, O>.mapAs(): Parser<I, E, OO> {
+    return this as Parser<I, E, OO>
 }
 
 /**

--- a/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/Parser.kt
+++ b/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/Parser.kt
@@ -1,8 +1,11 @@
 package com.mongodb.jbplugin.mql.parser
 
 import com.mongodb.jbplugin.mql.adt.Either
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.Executors
 
 /**
  * A Parser is a suspendable function that returns either an error or a valid output from a
@@ -207,4 +210,12 @@ fun <I, E, O> first(
 ): Parser<I, Either<NoConditionFulfilled, E>, O> {
     val branches = parsers.map { it.matches() to it }.toTypedArray()
     return cond(*branches)
+}
+
+private val PARSER = Executors.newWorkStealingPool(4).asCoroutineDispatcher()
+
+fun <I, E, O> Parser<I, E, O>.run(input: I): Either<E, O> {
+    return runBlocking(PARSER) {
+        this@run(input)
+    }
 }

--- a/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/Parser.kt
+++ b/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/Parser.kt
@@ -1,6 +1,7 @@
 package com.mongodb.jbplugin.mql.parser
 
 import com.mongodb.jbplugin.mql.adt.Either
+import com.mongodb.jbplugin.mql.adt.EitherInclusive
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -80,13 +81,6 @@ fun <I, E, O> Parser<I, E, O>.anyError(): Parser<I, Any, O> {
 /**
  * Returns a new parser that maps the output to a new type.
  */
-fun <OO, I, E, O> Parser<I, E, O>.castValue(): Parser<I, E, OO> {
-    return this as Parser<I, E, OO>
-}
-
-/**
- * Returns a new parser that maps the output to a new type.
- */
 fun <I, E, O, OO> Parser<I, E, O>.map(mapFn: (O) -> OO): Parser<I, E, OO> {
     return { input ->
         when (val result = this(input)) {
@@ -121,7 +115,7 @@ fun <I, E, O, EE> Parser<I, E, O>.mapError(mapFn: (E) -> EE): Parser<I, EE, O> {
  */
 fun <I, E, O, E2, O2> Parser<I, E, O>.zip(
     second: Parser<I, E2, O2>
-): Parser<I, Pair<E?, E2?>, Pair<O, O2>> {
+): Parser<I, EitherInclusive<E, E2>, Pair<O, O2>> {
     return { input ->
         coroutineScope {
             val firstJob = async { this@zip(input) }

--- a/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/Parser.kt
+++ b/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/Parser.kt
@@ -167,6 +167,11 @@ fun <I, E> not(parser: Parser<I, E, Boolean>): Parser<I, E, Boolean> {
     return parser.map { !it }
 }
 
+fun <I, E, O> otherwise(defaultValue: () -> O): Parser<I, E, O> {
+    val thenDefaultValue: Parser<I, E, O> = { input: I -> Either.right(defaultValue()) }
+    return thenDefaultValue
+}
+
 /**
  * Returns a parser that checks that the source parser would fail or not.
  */
@@ -214,8 +219,8 @@ fun <I, E, O> first(
 
 private val PARSER = Executors.newWorkStealingPool(4).asCoroutineDispatcher()
 
-fun <I, E, O> Parser<I, E, O>.run(input: I): Either<E, O> {
+fun <I, E, O> Parser<I, E, O>.parse(input: I): Either<E, O> {
     return runBlocking(PARSER) {
-        this@run(input)
+        this@parse(input)
     }
 }

--- a/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/components/HasCollectionReference.kt
+++ b/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/components/HasCollectionReference.kt
@@ -1,0 +1,20 @@
+package com.mongodb.jbplugin.mql.parser.components
+
+import com.mongodb.jbplugin.mql.Node
+import com.mongodb.jbplugin.mql.adt.Either
+import com.mongodb.jbplugin.mql.components.HasCollectionReference
+import com.mongodb.jbplugin.mql.parser.Parser
+
+data object NoCollectionReference
+
+inline fun <S, reified T : HasCollectionReference.CollectionReference<S>> collectionReference(): Parser<Node<S>, NoCollectionReference, T> {
+    return { input ->
+        when (val ref = input.component<HasCollectionReference<S>>()?.reference) {
+            null -> Either.left(NoCollectionReference)
+            is T -> Either.right(ref)
+            else -> Either.left(NoCollectionReference)
+        }
+    }
+}
+
+fun <S> knownCollection() = collectionReference<S, HasCollectionReference.Known<S>>()

--- a/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/components/HasCollectionReference.kt
+++ b/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/components/HasCollectionReference.kt
@@ -18,3 +18,4 @@ inline fun <S, reified T : HasCollectionReference.CollectionReference<S>> collec
 }
 
 fun <S> knownCollection() = collectionReference<S, HasCollectionReference.Known<S>>()
+fun <S> onlyCollection() = collectionReference<S, HasCollectionReference.OnlyCollection<S>>()

--- a/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/components/HasCollectionReference.kt
+++ b/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/components/HasCollectionReference.kt
@@ -17,5 +17,14 @@ inline fun <S, reified T : HasCollectionReference.CollectionReference<S>> collec
     }
 }
 
+fun <S> noCollection(): Parser<Node<S>, HasCollectionReference.CollectionReference<S>, Unit> {
+    return { input ->
+        when (val ref = input.component<HasCollectionReference<S>>()?.reference) {
+            null -> Either.right(Unit)
+            HasCollectionReference.Unknown -> Either.right(Unit)
+            else -> Either.left(ref)
+        }
+    }
+}
 fun <S> knownCollection() = collectionReference<S, HasCollectionReference.Known<S>>()
 fun <S> onlyCollection() = collectionReference<S, HasCollectionReference.OnlyCollection<S>>()

--- a/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/components/HasFieldReference.kt
+++ b/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/components/HasFieldReference.kt
@@ -1,0 +1,20 @@
+package com.mongodb.jbplugin.mql.parser.components
+
+import com.mongodb.jbplugin.mql.Node
+import com.mongodb.jbplugin.mql.adt.Either
+import com.mongodb.jbplugin.mql.components.HasFieldReference
+import com.mongodb.jbplugin.mql.parser.Parser
+
+data object NoFieldReference
+
+inline fun <reified T : HasFieldReference.FieldReference<S>, S> fieldReference(): Parser<Node<S>, NoFieldReference, T> {
+    return { input ->
+        when (val ref = input.component<HasFieldReference<S>>()?.reference) {
+            null -> Either.left(NoFieldReference)
+            is T -> Either.right(ref)
+            else -> Either.left(NoFieldReference)
+        }
+    }
+}
+
+fun <S> knownFieldReference() = fieldReference<HasFieldReference.Known<S>, S>()

--- a/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/components/HasFilter.kt
+++ b/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/components/HasFilter.kt
@@ -1,0 +1,39 @@
+package com.mongodb.jbplugin.mql.parser.components
+
+import com.mongodb.jbplugin.mql.Node
+import com.mongodb.jbplugin.mql.adt.Either
+import com.mongodb.jbplugin.mql.components.HasFilter
+import com.mongodb.jbplugin.mql.parser.Parser
+
+data object NoFilters
+
+fun <S> atLeastOneFilter(): Parser<Node<S>, NoFilters, List<Node<S>>> {
+    return { input ->
+        when (val ref = input.component<HasFilter<S>>()) {
+            null -> Either.left(NoFilters)
+            else -> if (ref.children.isNotEmpty()) {
+                Either.right(ref.children)
+            } else {
+                Either.left(NoFilters)
+            }
+        }
+    }
+}
+
+fun <S> allFiltersRecursively(): Parser<Node<S>, NoFilters, List<Node<S>>> {
+    return { input ->
+        fun gather(el: Node<S>): List<Node<S>> {
+            return when (val ref = el.component<HasFilter<S>>()) {
+                null -> emptyList()
+                else -> ref.children + ref.children.flatMap(::gather)
+            }
+        }
+
+        val result = gather(input)
+        if (result.isEmpty()) {
+            Either.left(NoFilters)
+        } else {
+            Either.right(result)
+        }
+    }
+}

--- a/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/components/HasSourceDialect.kt
+++ b/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/components/HasSourceDialect.kt
@@ -1,0 +1,16 @@
+package com.mongodb.jbplugin.mql.parser.components
+
+import com.mongodb.jbplugin.mql.Node
+import com.mongodb.jbplugin.mql.adt.Either
+import com.mongodb.jbplugin.mql.components.HasSourceDialect
+import com.mongodb.jbplugin.mql.parser.Parser
+
+data object NoSourceDialect
+fun <S> sourceDialect(): Parser<Node<S>, NoSourceDialect, HasSourceDialect.DialectName> {
+    return { input ->
+        when (val ref = input.component<HasSourceDialect>()) {
+            null -> Either.left(NoSourceDialect)
+            else -> Either.right(ref.name)
+        }
+    }
+}

--- a/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/components/HasUpdates.kt
+++ b/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/components/HasUpdates.kt
@@ -1,0 +1,21 @@
+package com.mongodb.jbplugin.mql.parser.components
+
+import com.mongodb.jbplugin.mql.Node
+import com.mongodb.jbplugin.mql.adt.Either
+import com.mongodb.jbplugin.mql.components.HasUpdates
+import com.mongodb.jbplugin.mql.parser.Parser
+
+data object NoUpdates
+
+fun <S> atLeastOneUpdate(): Parser<Node<S>, NoUpdates, List<Node<S>>> {
+    return { input ->
+        when (val ref = input.component<HasUpdates<S>>()) {
+            null -> Either.left(NoUpdates)
+            else -> if (ref.children.isNotEmpty()) {
+                Either.right(ref.children)
+            } else {
+                Either.left(NoUpdates)
+            }
+        }
+    }
+}

--- a/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/components/HasValueReference.kt
+++ b/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/components/HasValueReference.kt
@@ -1,9 +1,12 @@
 package com.mongodb.jbplugin.mql.parser.components
 
+import com.mongodb.jbplugin.mql.BsonType
 import com.mongodb.jbplugin.mql.Node
 import com.mongodb.jbplugin.mql.adt.Either
 import com.mongodb.jbplugin.mql.components.HasValueReference
 import com.mongodb.jbplugin.mql.parser.Parser
+import com.mongodb.jbplugin.mql.parser.first
+import com.mongodb.jbplugin.mql.parser.map
 
 data object NoValueReference
 
@@ -19,3 +22,10 @@ inline fun <reified T : HasValueReference.ValueReference<S>, S> valueReference()
 
 fun <S> constantValueReference() = valueReference<HasValueReference.Constant<S>, S>()
 fun <S> runtimeValueReference() = valueReference<HasValueReference.Runtime<S>, S>()
+
+data class ParsedValueReference<S, V>(val source: S, val type: BsonType, val value: V?)
+
+fun <S> extractValueReference() = first(
+    constantValueReference<S>().map { ParsedValueReference(it.source, it.type, it.value) },
+    runtimeValueReference<S>().map { ParsedValueReference(it.source, it.type, null) }
+)

--- a/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/components/HasValueReference.kt
+++ b/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/components/HasValueReference.kt
@@ -1,0 +1,21 @@
+package com.mongodb.jbplugin.mql.parser.components
+
+import com.mongodb.jbplugin.mql.Node
+import com.mongodb.jbplugin.mql.adt.Either
+import com.mongodb.jbplugin.mql.components.HasValueReference
+import com.mongodb.jbplugin.mql.parser.Parser
+
+data object NoValueReference
+
+inline fun <reified T : HasValueReference.ValueReference<S>, S> valueReference(): Parser<Node<S>, NoValueReference, T> {
+    return { input ->
+        when (val ref = input.component<HasValueReference<S>>()?.reference) {
+            null -> Either.left(NoValueReference)
+            is T -> Either.right(ref)
+            else -> Either.left(NoValueReference)
+        }
+    }
+}
+
+fun <S> constantValueReference() = valueReference<HasValueReference.Constant<S>, S>()
+fun <S> runtimeValueReference() = valueReference<HasValueReference.Runtime<S>, S>()


### PR DESCRIPTION
  A Parser is a suspendable function that returns either an error or a valid output from a
  lazy input. Parsers can be composed using different functions, like filter, map, mapError...
  All these compositions return a new Parser.
 
  To understand how a parser works, we need to think that parsers are a pipeline: the output of this parser is
  the input of the next parser.
 
  Parser are typesafe on input, error and output.
 
  Some examples, let's say we want to get the collection reference, if it's know, on a query. We
  would define the parser as the following:
 
  ```kt
  val knownCollRef = knownCollectionReference<S>();
  ```
 
  Note how we specify S in the knownCollectionReference parser. It's because S is generic in our
  model. This will return a parser of the following type:
 
  ```kt
  Parser<Node<S>, NoCollectionReference, HasCollectionReference.Known<S>>
  ```
 
  If we want to get the namespace object from it, we would create a new parser from this one, in
  this case, using the .map combinator:
 
  ```kt
  val knownNamespace = knownCollRef.map { it.namespace }
  ```
 
  The .map combinator wil create a new parser, that receives a `Node<S>`, because the input of
  `knownCollectionReference<S>` is a `Node<S>`, and the output is a Namespace object. The final type
  would be:
 
  ```kt
  Parser<Node<S>, NoCollectionReference, Namespace>
  ```

In this PR I'm refactoring FieldCheckingLinter to use the proposed parser combinator approach, which also allows to run the parsing in suspendable functions.
 