### PR TITLE
feat: adds support for parsing Aggregates.project stage INTELLIJ-126

### DIFF
--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/JavaDriverCompletionContributorTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/JavaDriverCompletionContributorTest.kt
@@ -352,4 +352,195 @@ public class Repository {
             },
         )
     }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Projections;import org.bson.Document;
+import org.bson.types.ObjectId;
+import java.util.List;
+import static com.mongodb.client.model.Filters.*;
+import static com.mongodb.client.model.Updates.*;
+
+public class Repository {
+    private final MongoClient client;
+
+    public Repository(MongoClient client) {
+        this.client = client;
+    }
+
+    public void exampleFind() {
+        client.getDatabase("myDatabase").getCollection("myCollection")
+                .aggregate(List.of(
+                    Aggregates.project(
+                        Projections.include("<caret>")
+                    )                
+                ));
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Projections#include of an Aggregates#project stage`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        fixture.specifyDialect(JavaDriverDialect)
+
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        val namespace = Namespace("myDatabase", "myCollection")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Projections;import org.bson.Document;
+import org.bson.types.ObjectId;
+import java.util.List;
+import static com.mongodb.client.model.Filters.*;
+import static com.mongodb.client.model.Updates.*;
+
+public class Repository {
+    private final MongoClient client;
+
+    public Repository(MongoClient client) {
+        this.client = client;
+    }
+
+    public void exampleFind() {
+        client.getDatabase("myDatabase").getCollection("myCollection")
+                .aggregate(List.of(
+                    Aggregates.project(
+                        Projections.exclude("<caret>")
+                    )                
+                ));
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Projections#exclude of an Aggregates#project stage`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        fixture.specifyDialect(JavaDriverDialect)
+
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        val namespace = Namespace("myDatabase", "myCollection")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Projections;import org.bson.Document;
+import org.bson.types.ObjectId;
+import java.util.List;
+import static com.mongodb.client.model.Filters.*;
+import static com.mongodb.client.model.Updates.*;
+
+public class Repository {
+    private final MongoClient client;
+
+    public Repository(MongoClient client) {
+        this.client = client;
+    }
+
+    public void exampleFind() {
+        client.getDatabase("myDatabase").getCollection("myCollection")
+                .aggregate(List.of(
+                    Aggregates.project(
+                        Projections.fields(
+                            Projections.exclude("<caret>")
+                        )
+                    )                
+                ));
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Projections#fields of an Aggregates#project stage`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        fixture.specifyDialect(JavaDriverDialect)
+
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        val namespace = Namespace("myDatabase", "myCollection")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+    }
 }

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/JavaDriverMongoDbAutocompletionPopupHandlerTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/JavaDriverMongoDbAutocompletionPopupHandlerTest.kt
@@ -358,4 +358,198 @@ public class Repository {
             },
         )
     }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Projections;import org.bson.Document;
+import org.bson.types.ObjectId;
+import java.util.List;
+import static com.mongodb.client.model.Filters.*;
+import static com.mongodb.client.model.Updates.*;
+
+public class Repository {
+    private final MongoClient client;
+
+    public Repository(MongoClient client) {
+        this.client = client;
+    }
+
+    public void exampleFind() {
+        client.getDatabase("myDatabase").getCollection("myCollection")
+                .aggregate(List.of(
+                    Aggregates.project(
+                        Projections.include(<caret>)
+                    )                
+                ));
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Projections#include of an Aggregates#project stage`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        fixture.specifyDialect(JavaDriverDialect)
+
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        val namespace = Namespace("myDatabase", "myCollection")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        fixture.type('"')
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Projections;import org.bson.Document;
+import org.bson.types.ObjectId;
+import java.util.List;
+import static com.mongodb.client.model.Filters.*;
+import static com.mongodb.client.model.Updates.*;
+
+public class Repository {
+    private final MongoClient client;
+
+    public Repository(MongoClient client) {
+        this.client = client;
+    }
+
+    public void exampleFind() {
+        client.getDatabase("myDatabase").getCollection("myCollection")
+                .aggregate(List.of(
+                    Aggregates.project(
+                        Projections.exclude(<caret>)
+                    )                
+                ));
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Projections#exclude of an Aggregates#project stage`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        fixture.specifyDialect(JavaDriverDialect)
+
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        val namespace = Namespace("myDatabase", "myCollection")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        fixture.type('"')
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Projections;import org.bson.Document;
+import org.bson.types.ObjectId;
+import java.util.List;
+import static com.mongodb.client.model.Filters.*;
+import static com.mongodb.client.model.Updates.*;
+
+public class Repository {
+    private final MongoClient client;
+
+    public Repository(MongoClient client) {
+        this.client = client;
+    }
+
+    public void exampleFind() {
+        client.getDatabase("myDatabase").getCollection("myCollection")
+                .aggregate(List.of(
+                    Aggregates.project(
+                        Projections.fields(
+                            Projections.exclude(<caret>)
+                        )
+                    )                
+                ));
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Projections#fields of an Aggregates#project stage`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        fixture.specifyDialect(JavaDriverDialect)
+
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        val namespace = Namespace("myDatabase", "myCollection")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        fixture.type('"')
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+    }
 }

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/impl/JavaDriverFieldCheckLinterInspectionTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/impl/JavaDriverFieldCheckLinterInspectionTest.kt
@@ -287,4 +287,84 @@ public class Repository {
         fixture.enableInspections(FieldCheckInspectionBridge::class.java)
         fixture.testHighlighting()
     }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Projections;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.bson.types.ObjectId;
+import java.util.List;
+import static com.mongodb.client.model.Filters.*;
+
+public class Repository {
+    private final MongoClient client;
+
+    public Repository(MongoClient client) {
+        this.client = client;
+    }
+
+    public AggregateIterable<Document> exampleAggregateInclude() {
+        return client.getDatabase("myDatabase")
+                .getCollection("myCollection")
+                .aggregate(List.of(
+                    Aggregates.project(
+                        Projections.include(<warning descr="Field \"nonExistingField\" does not exist in collection \"myDatabase.myCollection\"">"nonExistingField"</warning>)
+                    )
+                ));
+    }
+    
+    public AggregateIterable<Document> exampleAggregateExclude() {
+        return client.getDatabase("myDatabase")
+                .getCollection("myCollection")
+                .aggregate(List.of(
+                    Aggregates.project(
+                        Projections.exclude(<warning descr="Field \"nonExistingField\" does not exist in collection \"myDatabase.myCollection\"">"nonExistingField"</warning>)
+                    )
+                ));
+    }
+    
+    private Bson getAnotherProjection() {
+        return Projections.exclude(<warning descr="Field \"nonExistingField\" does not exist in collection \"myDatabase.myCollection\"">"nonExistingField"</warning>);
+    }
+    
+    public AggregateIterable<Document> exampleAggregateFields() {
+        Bson includeProject = Projections.include(<warning descr="Field \"nonExistingField\" does not exist in collection \"myDatabase.myCollection\"">"nonExistingField"</warning>);
+        return client.getDatabase("myDatabase")
+                .getCollection("myCollection")
+                .aggregate(List.of(
+                    Aggregates.project(
+                        Projections.fields(
+                            Projections.exclude(<warning descr="Field \"nonExistingField\" does not exist in collection \"myDatabase.myCollection\"">"nonExistingField"</warning>),
+                            includeProject,
+                            getAnotherProjection()
+                        )
+                    )
+                ));
+    }
+}
+        """,
+    )
+    fun `shows an inspection for Aggregates#project call when the field does not exist in the current namespace`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDialect(JavaDriverDialect)
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), any<GetCollectionSchema.Slice>())
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(Namespace("myDatabase", "myCollection"), BsonObject(emptyMap()))
+            ),
+        )
+
+        fixture.enableInspections(FieldCheckInspectionBridge::class.java)
+        fixture.testHighlighting()
+    }
 }

--- a/packages/jetbrains-plugin/src/test/resources/project-fixtures/basic-java-project-with-mongodb/src/main/java/alt/mongodb/javadriver/JavaDriverRepository.java
+++ b/packages/jetbrains-plugin/src/test/resources/project-fixtures/basic-java-project-with-mongodb/src/main/java/alt/mongodb/javadriver/JavaDriverRepository.java
@@ -3,6 +3,7 @@ package alt.mongodb.javadriver;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.model.Aggregates;
 import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
 import org.bson.Document;
 
 import java.util.ArrayList;
@@ -48,9 +49,18 @@ public class JavaDriverRepository {
         return client
             .getDatabase("sample_mflix")
             .getCollection("movies")
-            .aggregate(List.of(Aggregates.match(
-                Filters.eq("year", year)
-            )))
+            .aggregate(
+                List.of(
+                    Aggregates.match(
+                        Filters.eq("year", year)
+                    ),
+                    Aggregates.project(
+                        Projections.fields(
+                            Projections.include("year", "plot")
+                        )
+                    )
+                )
+            )
             .into(new ArrayList<>());
     }
 }

--- a/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParser.kt
+++ b/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParser.kt
@@ -222,7 +222,8 @@ object JavaDriverDialectParser : DialectParser<PsiElement> {
         val methodCall = element.parentOfType<PsiMethodCallExpression>(false) ?: return false
         val containingClass = methodCall.resolveMethod()?.containingClass ?: return false
 
-        return containingClass.qualifiedName == AGGREGATES_FQN
+        return containingClass.qualifiedName == AGGREGATES_FQN ||
+            containingClass.qualifiedName == PROJECTIONS_FQN
     }
 
     private fun resolveToFiltersCall(element: PsiElement): PsiMethodCallExpression? {

--- a/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParser.kt
+++ b/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParser.kt
@@ -456,8 +456,6 @@ object JavaDriverDialectParser : DialectParser<PsiElement> {
 
                 val parsedProjections = parseProjectionExpression(resolvedProjectionExpression)
 
-                println(":: $parsedProjections")
-
                 return nodeWithProjections(parsedProjections)
             }
 

--- a/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/PsiMdbTreeUtil.kt
+++ b/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/PsiMdbTreeUtil.kt
@@ -332,6 +332,15 @@ fun PsiElement.tryToResolveAsConstant(): Pair<Boolean, Any?> {
         meaningfulThis.hasModifier(JvmModifier.FINAL)
     ) {
         return meaningfulThis.initializer!!.tryToResolveAsConstant()
+    } else if (meaningfulThis is PsiMethodCallExpression) {
+        val methodCall = meaningfulThis.fuzzyResolveMethod() ?: return false to null
+        return PsiTreeUtil.findChildrenOfType(
+            methodCall.body,
+            PsiReturnStatement::class.java
+        )
+            .mapNotNull { it.returnValue }
+            .map { it.tryToResolveAsConstant() }
+            .firstOrNull { it.first } ?: (false to null)
     }
 
     return false to null

--- a/packages/mongodb-dialects/java-driver/src/test/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/aggregationparser/AggregationParserTest.kt
+++ b/packages/mongodb-dialects/java-driver/src/test/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/aggregationparser/AggregationParserTest.kt
@@ -1,0 +1,212 @@
+package com.mongodb.jbplugin.dialects.javadriver.glossary.aggregationparser
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.psi.util.PsiTreeUtil
+import com.mongodb.jbplugin.dialects.javadriver.IntegrationTest
+import com.mongodb.jbplugin.dialects.javadriver.ParsingTest
+import com.mongodb.jbplugin.dialects.javadriver.getQueryAtMethod
+import com.mongodb.jbplugin.dialects.javadriver.glossary.JavaDriverDialect
+import com.mongodb.jbplugin.dialects.javadriver.glossary.JavaDriverDialectParser
+import com.mongodb.jbplugin.mql.components.HasAggregation
+import com.mongodb.jbplugin.mql.components.HasCollectionReference
+import com.mongodb.jbplugin.mql.components.HasSourceDialect
+import com.mongodb.jbplugin.mql.components.IsCommand
+import org.junit.jupiter.api.Assertions.*
+
+@IntegrationTest
+class AggregationParserTest {
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+
+    public Document findBookById(ObjectId id) {
+        return this.collection.aggregate(List.of()).first();
+    }
+}
+      """
+    )
+    fun `should identify an aggregation as a valid candidate for parsing`(psiFile: PsiFile) {
+        val query = psiFile.getQueryAtMethod("Aggregation", "findBookById")
+        // The entire aggregation is not a valid candidate
+        assertFalse(JavaDriverDialectParser.isCandidateForQuery(query))
+
+        val actualQuery = PsiTreeUtil
+            .findChildrenOfType(query, PsiMethodCallExpression::class.java)
+            .first { it.text.endsWith("of())") }
+        // Only the collection call is the valid query
+        assertTrue(JavaDriverDialectParser.isCandidateForQuery(actualQuery))
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+
+    public Document findBookById(ObjectId id) {
+        return this.collection.aggregate(List.of()).first();
+    }
+}
+      """
+    )
+    fun `should consider the MongoCollection#aggregate as the attachment for query`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Aggregation", "findBookById")
+        val actualQuery = PsiTreeUtil
+            .findChildrenOfType(query, PsiMethodCallExpression::class.java)
+            .first { it.text.endsWith("of())") }
+
+        assertEquals(actualQuery, JavaDriverDialectParser.attachment(actualQuery))
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+
+    public Document findBookById(ObjectId id) {
+        return this.collection.aggregate(List.of()).first();
+    }
+}
+        """,
+    )
+    fun `can extract the namespace of an aggregate`(psiFile: PsiFile) {
+        val query = psiFile.getQueryAtMethod("Aggregation", "findBookById")
+        val actualQuery = PsiTreeUtil
+            .findChildrenOfType(query, PsiMethodCallExpression::class.java)
+            .first { it.text.endsWith("of())") }
+        val parsedAggregate = JavaDriverDialect.parser.parse(actualQuery)
+
+        val knownReference = parsedAggregate.component<HasCollectionReference<*>>()?.reference as HasCollectionReference.Known
+        val command = parsedAggregate.component<IsCommand>()
+        val dialect = parsedAggregate.component<HasSourceDialect>()
+        val namespace = knownReference.namespace
+
+        assertEquals(HasSourceDialect.DialectName.JAVA_DRIVER, dialect?.name)
+        assertEquals("simple", namespace.database)
+        assertEquals("books", namespace.collection)
+        assertEquals(IsCommand.CommandType.AGGREGATE, command?.type)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+
+    public Document findBookById(ObjectId id) {
+        return this.collection.aggregate(List.of()).first();
+    }
+}
+        """,
+    )
+    fun `should be able to parse an empty aggregation built with List#of method`(psiFile: PsiFile) {
+        val query = psiFile.getQueryAtMethod("Aggregation", "findBookById")
+        val actualQuery = PsiTreeUtil
+            .findChildrenOfType(query, PsiMethodCallExpression::class.java)
+            .first { it.text.endsWith("of())") }
+        val parsedAggregate = JavaDriverDialect.parser.parse(actualQuery)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+
+        assertNotNull(hasAggregation)
+        assertEquals(hasAggregation?.children?.isEmpty(), true)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.Arrays;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+
+    public Document findBookById(ObjectId id) {
+        return this.collection.aggregate(Arrays.asList()).first();
+    }
+}
+        """,
+    )
+    fun `should be able to parse an empty aggregation built with Arrays#asList method`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Aggregation", "findBookById")
+        val actualQuery = PsiTreeUtil
+            .findChildrenOfType(query, PsiMethodCallExpression::class.java)
+            .first { it.text.endsWith("asList())") }
+        val parsedAggregate = JavaDriverDialect.parser.parse(actualQuery)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+
+        assertNotNull(hasAggregation)
+        assertEquals(hasAggregation?.children?.isEmpty(), true)
+    }
+}

--- a/packages/mongodb-dialects/java-driver/src/test/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/aggregationparser/MatchStageParserTest.kt
+++ b/packages/mongodb-dialects/java-driver/src/test/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/aggregationparser/MatchStageParserTest.kt
@@ -1,245 +1,29 @@
-package com.mongodb.jbplugin.dialects.javadriver.glossary
+package com.mongodb.jbplugin.dialects.javadriver.glossary.aggregationparser
 
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
-import com.intellij.psi.PsiMethodCallExpression
-import com.intellij.psi.util.PsiTreeUtil
 import com.mongodb.jbplugin.dialects.javadriver.IntegrationTest
 import com.mongodb.jbplugin.dialects.javadriver.ParsingTest
 import com.mongodb.jbplugin.dialects.javadriver.getQueryAtMethod
+import com.mongodb.jbplugin.dialects.javadriver.glossary.JavaDriverDialect
 import com.mongodb.jbplugin.mql.Node
 import com.mongodb.jbplugin.mql.components.HasAggregation
-import com.mongodb.jbplugin.mql.components.HasCollectionReference
 import com.mongodb.jbplugin.mql.components.HasFieldReference
 import com.mongodb.jbplugin.mql.components.HasFieldReference.FromSchema
 import com.mongodb.jbplugin.mql.components.HasFilter
-import com.mongodb.jbplugin.mql.components.HasSourceDialect
 import com.mongodb.jbplugin.mql.components.HasValueReference
 import com.mongodb.jbplugin.mql.components.HasValueReference.Constant
-import com.mongodb.jbplugin.mql.components.IsCommand
 import com.mongodb.jbplugin.mql.components.Name
 import com.mongodb.jbplugin.mql.components.Named
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
 
 @IntegrationTest
-class AggregationParserTest {
-
+class MatchStageParserTest {
     @ParsingTest(
         fileName = "Aggregation.java",
         value = """
+import com.mongodb.client.AggregateIterable;
 import com.mongodb.client.MongoClient;
-import com.mongodb.client.MongoCollection;
-import org.bson.Document;
-import org.bson.types.ObjectId;
-
-import java.util.List;
-
-import static com.mongodb.client.model.Filters.*;
-
-public final class Aggregation {
-    private final MongoCollection<Document> collection;
-
-    public Aggregation(MongoClient client) {
-        this.collection = client.getDatabase("simple").getCollection("books");
-    }
-
-    public Document findBookById(ObjectId id) {
-        return this.collection.aggregate(List.of()).first();
-    }
-}
-      """
-    )
-    fun `should identify an aggregation as a valid candidate for parsing`(psiFile: PsiFile) {
-        val query = psiFile.getQueryAtMethod("Aggregation", "findBookById")
-        // The entire aggregation is not a valid candidate
-        assertFalse(JavaDriverDialectParser.isCandidateForQuery(query))
-
-        val actualQuery = PsiTreeUtil
-            .findChildrenOfType(query, PsiMethodCallExpression::class.java)
-            .first { it.text.endsWith("of())") }
-        // Only the collection call is the valid query
-        assertTrue(JavaDriverDialectParser.isCandidateForQuery(actualQuery))
-    }
-
-    @ParsingTest(
-        fileName = "Aggregation.java",
-        value = """
-import com.mongodb.client.MongoClient;
-import com.mongodb.client.MongoCollection;
-import org.bson.Document;
-import org.bson.types.ObjectId;
-
-import java.util.List;
-
-import static com.mongodb.client.model.Filters.*;
-
-public final class Aggregation {
-    private final MongoCollection<Document> collection;
-
-    public Aggregation(MongoClient client) {
-        this.collection = client.getDatabase("simple").getCollection("books");
-    }
-
-    public Document findBookById(ObjectId id) {
-        return this.collection.aggregate(List.of()).first();
-    }
-}
-      """
-    )
-    fun `should consider the MongoCollection#aggregate as the attachment for query`(
-        psiFile: PsiFile
-    ) {
-        val query = psiFile.getQueryAtMethod("Aggregation", "findBookById")
-        val actualQuery = PsiTreeUtil
-            .findChildrenOfType(query, PsiMethodCallExpression::class.java)
-            .first { it.text.endsWith("of())") }
-
-        assertEquals(actualQuery, JavaDriverDialectParser.attachment(actualQuery))
-    }
-
-    @ParsingTest(
-        fileName = "Aggregation.java",
-        value = """
-import com.mongodb.client.MongoClient;
-import com.mongodb.client.MongoCollection;
-import org.bson.Document;
-import org.bson.types.ObjectId;
-
-import java.util.List;
-
-import static com.mongodb.client.model.Filters.*;
-
-public final class Aggregation {
-    private final MongoCollection<Document> collection;
-
-    public Aggregation(MongoClient client) {
-        this.collection = client.getDatabase("simple").getCollection("books");
-    }
-
-    public Document findBookById(ObjectId id) {
-        return this.collection.aggregate(List.of()).first();
-    }
-}
-        """,
-    )
-    fun `can extract the namespace of an aggregate`(psiFile: PsiFile) {
-        val query = psiFile.getQueryAtMethod("Aggregation", "findBookById")
-        val actualQuery = PsiTreeUtil
-            .findChildrenOfType(query, PsiMethodCallExpression::class.java)
-            .first { it.text.endsWith("of())") }
-        val parsedAggregate = JavaDriverDialect.parser.parse(actualQuery)
-
-        val knownReference = parsedAggregate.component<HasCollectionReference<*>>()?.reference as HasCollectionReference.Known
-        val command = parsedAggregate.component<IsCommand>()
-        val dialect = parsedAggregate.component<HasSourceDialect>()
-        val namespace = knownReference.namespace
-
-        assertEquals(HasSourceDialect.DialectName.JAVA_DRIVER, dialect?.name)
-        assertEquals("simple", namespace.database)
-        assertEquals("books", namespace.collection)
-        assertEquals(IsCommand.CommandType.AGGREGATE, command?.type)
-    }
-
-    @ParsingTest(
-        fileName = "Aggregation.java",
-        value = """
-import com.mongodb.client.MongoClient;
-import com.mongodb.client.MongoCollection;
-import org.bson.Document;
-import org.bson.types.ObjectId;
-
-import java.util.List;
-
-import static com.mongodb.client.model.Filters.*;
-
-public final class Aggregation {
-    private final MongoCollection<Document> collection;
-
-    public Aggregation(MongoClient client) {
-        this.collection = client.getDatabase("simple").getCollection("books");
-    }
-
-    public Document findBookById(ObjectId id) {
-        return this.collection.aggregate(List.of()).first();
-    }
-}
-        """,
-    )
-    fun `should be able to parse an empty aggregation built with List#of method`(psiFile: PsiFile) {
-        val query = psiFile.getQueryAtMethod("Aggregation", "findBookById")
-        val actualQuery = PsiTreeUtil
-            .findChildrenOfType(query, PsiMethodCallExpression::class.java)
-            .first { it.text.endsWith("of())") }
-        val parsedAggregate = JavaDriverDialect.parser.parse(actualQuery)
-        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
-
-        assertNotNull(hasAggregation)
-        assertEquals(hasAggregation?.children?.isEmpty(), true)
-    }
-
-    @ParsingTest(
-        fileName = "Aggregation.java",
-        value = """
-import com.mongodb.client.MongoClient;
-import com.mongodb.client.MongoCollection;
-import org.bson.Document;
-import org.bson.types.ObjectId;
-
-import java.util.Arrays;
-
-import static com.mongodb.client.model.Filters.*;
-
-public final class Aggregation {
-    private final MongoCollection<Document> collection;
-
-    public Aggregation(MongoClient client) {
-        this.collection = client.getDatabase("simple").getCollection("books");
-    }
-
-    public Document findBookById(ObjectId id) {
-        return this.collection.aggregate(Arrays.asList()).first();
-    }
-}
-        """,
-    )
-    fun `should be able to parse an empty aggregation built with Arrays#asList method`(
-        psiFile: PsiFile
-    ) {
-        val query = psiFile.getQueryAtMethod("Aggregation", "findBookById")
-        val actualQuery = PsiTreeUtil
-            .findChildrenOfType(query, PsiMethodCallExpression::class.java)
-            .first { it.text.endsWith("asList())") }
-        val parsedAggregate = JavaDriverDialect.parser.parse(actualQuery)
-        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
-
-        assertNotNull(hasAggregation)
-        assertEquals(hasAggregation?.children?.isEmpty(), true)
-    }
-
-    // Assuming that the Filters remains the same in the provided test file
-    private fun commonAssertionsOnMatchStageNode(matchStageNode: Node<PsiElement>) {
-        val named = matchStageNode.component<Named>()!!
-        assertEquals(Name.MATCH, named.name)
-
-        val hasFilters = matchStageNode.component<HasFilter<PsiElement>>()!!
-        assertEquals(hasFilters.children.size, 1)
-
-        val filterNode = hasFilters.children[0]
-
-        val filterNameComponent = filterNode.component<Named>()!!
-        assertEquals(Name.EQ, filterNameComponent.name)
-
-        val fieldReferenceComponent = filterNode.component<HasFieldReference<PsiElement>>()!!
-        assertEquals((fieldReferenceComponent.reference as FromSchema).fieldName, "name")
-
-        val valueReferenceComponent = filterNode.component<HasValueReference<PsiElement>>()!!
-        assertEquals((valueReferenceComponent.reference as Constant).value, "MongoDB")
-    }
-
-    @ParsingTest(
-        fileName = "Aggregation.java",
-        value = """
-import com.mongodb.client.AggregateIterable;import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Aggregates;
 import com.mongodb.client.model.Filters;
@@ -278,7 +62,8 @@ public final class Aggregation {
     @ParsingTest(
         fileName = "Aggregation.java",
         value = """
-import com.mongodb.client.AggregateIterable;import com.mongodb.client.MongoClient;
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Aggregates;
 import com.mongodb.client.model.Filters;
@@ -318,7 +103,8 @@ public final class Aggregation {
     @ParsingTest(
         fileName = "Aggregation.java",
         value = """
-import com.mongodb.client.AggregateIterable;import com.mongodb.client.MongoClient;
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Aggregates;
 import com.mongodb.client.model.Filters;
@@ -361,7 +147,8 @@ public final class Aggregation {
     @ParsingTest(
         fileName = "Aggregation.java",
         value = """
-import com.mongodb.client.AggregateIterable;import com.mongodb.client.MongoClient;
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Aggregates;
 import com.mongodb.client.model.Filters;
@@ -402,7 +189,8 @@ public final class Aggregation {
     @ParsingTest(
         fileName = "Aggregation.java",
         value = """
-import com.mongodb.client.AggregateIterable;import com.mongodb.client.MongoClient;
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Aggregates;
 import com.mongodb.client.model.Filters;
@@ -446,7 +234,8 @@ public final class Aggregation {
     @ParsingTest(
         fileName = "Aggregation.java",
         value = """
-import com.mongodb.client.AggregateIterable;import com.mongodb.client.MongoClient;
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Aggregates;
 import com.mongodb.client.model.Filters;
@@ -491,7 +280,8 @@ public final class Aggregation {
     @ParsingTest(
         fileName = "Aggregation.java",
         value = """
-import com.mongodb.client.AggregateIterable;import com.mongodb.client.MongoClient;
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Aggregates;
 import com.mongodb.client.model.Filters;
@@ -534,5 +324,26 @@ public final class Aggregation {
         val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
         assertEquals(hasAggregation?.children?.size, 1)
         commonAssertionsOnMatchStageNode(hasAggregation?.children?.get(0)!!)
+    }
+
+    companion object {
+        private fun commonAssertionsOnMatchStageNode(matchStageNode: Node<PsiElement>) {
+            val named = matchStageNode.component<Named>()!!
+            assertEquals(Name.MATCH, named.name)
+
+            val hasFilters = matchStageNode.component<HasFilter<PsiElement>>()!!
+            assertEquals(hasFilters.children.size, 1)
+
+            val filterNode = hasFilters.children[0]
+
+            val filterNameComponent = filterNode.component<Named>()!!
+            assertEquals(Name.EQ, filterNameComponent.name)
+
+            val fieldReferenceComponent = filterNode.component<HasFieldReference<PsiElement>>()!!
+            assertEquals((fieldReferenceComponent.reference as FromSchema).fieldName, "name")
+
+            val valueReferenceComponent = filterNode.component<HasValueReference<PsiElement>>()!!
+            assertEquals((valueReferenceComponent.reference as Constant).value, "MongoDB")
+        }
     }
 }

--- a/packages/mongodb-dialects/java-driver/src/test/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/aggregationparser/ProjectStageParserTest.kt
+++ b/packages/mongodb-dialects/java-driver/src/test/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/aggregationparser/ProjectStageParserTest.kt
@@ -1,0 +1,1320 @@
+package com.mongodb.jbplugin.dialects.javadriver.glossary.aggregationparser
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.mongodb.jbplugin.dialects.javadriver.IntegrationTest
+import com.mongodb.jbplugin.dialects.javadriver.ParsingTest
+import com.mongodb.jbplugin.dialects.javadriver.getQueryAtMethod
+import com.mongodb.jbplugin.dialects.javadriver.glossary.JavaDriverDialect
+import com.mongodb.jbplugin.mql.Node
+import com.mongodb.jbplugin.mql.components.HasAggregation
+import com.mongodb.jbplugin.mql.components.HasFieldReference
+import com.mongodb.jbplugin.mql.components.HasFieldReference.FromSchema
+import com.mongodb.jbplugin.mql.components.HasProjections
+import com.mongodb.jbplugin.mql.components.HasValueReference
+import com.mongodb.jbplugin.mql.components.HasValueReference.Inferred
+import com.mongodb.jbplugin.mql.components.Name
+import com.mongodb.jbplugin.mql.components.Named
+import org.junit.jupiter.api.Assertions.assertEquals
+
+@IntegrationTest
+class ProjectStageParserTest {
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        return this.collection.aggregate(List.of(
+            Aggregates.project()
+        ));
+    }
+}
+      """
+    )
+    fun `should be able to parse an empty project call`(psiFile: PsiFile) {
+        val aggregate = psiFile.getQueryAtMethod("Aggregation", "getAllBookTitles")
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val projectStageNode = hasAggregation?.children?.get(0)!!
+
+        val named = projectStageNode.component<Named>()!!
+        assertEquals(Name.PROJECT, named.name)
+
+        assertEquals(0, projectStageNode.component<HasProjections<PsiElement>>()!!.children.size)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String yearField = "year"; 
+        return this.collection.aggregate(List.of(
+            Aggregates.project(
+                Projections.include("title", yearField, getAuthorField())
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Projection#include - should be able to parse with varargs`(psiFile: PsiFile) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val projectStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForIncludeProjection(projectStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String yearField = "year";
+        return this.collection.aggregate(List.of(
+            Aggregates.project(
+                Projections.include(
+                    List.of("title", yearField, getAuthorField())
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Projection#include - should be able to parse with List#of`(psiFile: PsiFile) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val projectStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForIncludeProjection(projectStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String yearField = "year";
+        List<String> projectedFields = List.of("title", yearField, getAuthorField());
+        return this.collection.aggregate(List.of(
+            Aggregates.project(
+                Projections.include(
+                    projectedFields
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Projection#include - should be able to parse with List#of when the list is a variable`(
+        psiFile: PsiFile
+    ) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val projectStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForIncludeProjection(projectStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+    
+    private List<String> getProjectedFields() {
+        String yearField = "year";
+        return List.of("title", yearField, getAuthorField());
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        return this.collection.aggregate(List.of(
+            Aggregates.project(
+                Projections.include(
+                    getProjectedFields()
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Projection#include - should be able to parse with List#of when the list is from a method call`(
+        psiFile: PsiFile
+    ) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val projectStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForIncludeProjection(projectStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+import java.util.Arrays;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String yearField = "year";
+        return this.collection.aggregate(List.of(
+            Aggregates.project(
+                Projections.include(
+                    Arrays.asList("title", yearField, getAuthorField())
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Projection#include - should be able to parse with Arrays#asList`(psiFile: PsiFile) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val projectStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForIncludeProjection(projectStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String yearField = "year";
+        List<String> projectedFields = Arrays.asList("title", yearField, getAuthorField());
+        return this.collection.aggregate(List.of(
+            Aggregates.project(
+                Projections.include(
+                    projectedFields
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Projection#include - should be able to parse with Arrays#asList when the list is a variable`(
+        psiFile: PsiFile
+    ) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val projectStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForIncludeProjection(projectStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+    
+    private List<String> getProjectedFields() {
+        String yearField = "year";
+        return Arrays.asList("title", yearField, getAuthorField());
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        return this.collection.aggregate(List.of(
+            Aggregates.project(
+                Projections.include(
+                    getProjectedFields()
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Projection#include - should be able to parse with Arrays#asList when the list is from a method call`(
+        psiFile: PsiFile
+    ) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val projectStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForIncludeProjection(projectStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String yearField = "year"; 
+        return this.collection.aggregate(List.of(
+            Aggregates.project(
+                Projections.exclude("title", yearField, getAuthorField())
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Projection#exclude - should be able to parse with varargs`(psiFile: PsiFile) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val projectStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForExcludeProjection(projectStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String yearField = "year";
+        return this.collection.aggregate(List.of(
+            Aggregates.project(
+                Projections.exclude(
+                    List.of("title", yearField, getAuthorField())
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Projection#exclude - should be able to parse with List#of`(psiFile: PsiFile) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val projectStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForExcludeProjection(projectStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String yearField = "year";
+        List<String> projectedFields = List.of("title", yearField, getAuthorField());
+        return this.collection.aggregate(List.of(
+            Aggregates.project(
+                Projections.exclude(
+                    projectedFields
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Projection#exclude - should be able to parse with List#of when the list is a variable`(
+        psiFile: PsiFile
+    ) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val projectStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForExcludeProjection(projectStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+    
+    private List<String> getProjectedFields() {
+        String yearField = "year";
+        return List.of("title", yearField, getAuthorField());
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        return this.collection.aggregate(List.of(
+            Aggregates.project(
+                Projections.exclude(
+                    getProjectedFields()
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Projection#exclude - should be able to parse with List#of when the list is from a method call`(
+        psiFile: PsiFile
+    ) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val projectStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForExcludeProjection(projectStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+import java.util.Arrays;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String yearField = "year";
+        return this.collection.aggregate(List.of(
+            Aggregates.project(
+                Projections.exclude(
+                    Arrays.asList("title", yearField, getAuthorField())
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Projection#exclude - should be able to parse with Arrays#asList`(psiFile: PsiFile) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val projectStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForExcludeProjection(projectStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String yearField = "year";
+        List<String> projectedFields = Arrays.asList("title", yearField, getAuthorField());
+        return this.collection.aggregate(List.of(
+            Aggregates.project(
+                Projections.exclude(
+                    projectedFields
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Projection#exclude - should be able to parse with Arrays#asList when the list is a variable`(
+        psiFile: PsiFile
+    ) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val projectStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForExcludeProjection(projectStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+    
+    private List<String> getProjectedFields() {
+        String yearField = "year";
+        return Arrays.asList("title", yearField, getAuthorField());
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        return this.collection.aggregate(List.of(
+            Aggregates.project(
+                Projections.exclude(
+                    getProjectedFields()
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Projection#exclude - should be able to parse with Arrays#asList when the list is from a method call`(
+        psiFile: PsiFile
+    ) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val projectStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForExcludeProjection(projectStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+    
+    private Bson getThirdProjection() {
+        return Projections.exclude(Arrays.asList("published", getAuthorField()));
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String yearField = "year";
+        Bson secondProjection = Projections.include(List.of(yearField));
+        return this.collection.aggregate(List.of(
+            Aggregates.project(
+                Projections.fields(
+                    Projections.include("title"),
+                    secondProjection,
+                    getThirdProjection()
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Projection#fields - should be able to parse with varargs`(psiFile: PsiFile) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val projectStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForFieldsProjection(projectStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+    
+    private Bson getThirdProjection() {
+        return Projections.exclude(Arrays.asList("published", getAuthorField()));
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String yearField = "year";
+        Bson secondProjection = Projections.include(List.of(yearField));
+        return this.collection.aggregate(List.of(
+            Aggregates.project(
+                Projections.fields(
+                    List.of(
+                        Projections.include("title"),
+                        secondProjection,
+                        getThirdProjection()
+                    )
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Projection#fields - should be able to parse with List#of`(psiFile: PsiFile) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val projectStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForFieldsProjection(projectStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.bson.conversions.Bson;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+    
+    private Bson getThirdProjection() {
+        return Projections.exclude(Arrays.asList("published", getAuthorField()));
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String yearField = "year";
+        Bson secondProjection = Projections.include(List.of(yearField));
+        List<Bson> projections = List.of(
+            Projections.include("title"),
+            secondProjection,
+            getThirdProjection()
+        );
+        return this.collection.aggregate(List.of(
+            Aggregates.project(
+                Projections.fields(
+                    projections
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Projection#fields - should be able to parse with List#of when the list is a variable`(
+        psiFile: PsiFile
+    ) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val projectStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForFieldsProjection(projectStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.bson.conversions.Bson;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+    
+    private Bson getThirdProjection() {
+        return Projections.exclude(Arrays.asList("published", getAuthorField()));
+    }
+    
+    private List<Bson> getProjections() {
+        String yearField = "year";
+        Bson secondProjection = Projections.include(List.of(yearField));
+        return List.of(
+            Projections.include("title"),
+            secondProjection,
+            getThirdProjection()
+        );
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        return this.collection.aggregate(List.of(
+            Aggregates.project(
+                Projections.fields(
+                    getProjections()
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Projection#fields - should be able to parse with List#of when the list comes from a method call`(
+        psiFile: PsiFile
+    ) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val projectStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForFieldsProjection(projectStageNode)
+    }
+
+    companion object {
+        fun commonAssertionsForIncludeProjection(projectStageNode: Node<PsiElement>) {
+            val named = projectStageNode.component<Named>()!!
+            assertEquals(Name.PROJECT, named.name)
+
+            val projections = projectStageNode.component<HasProjections<PsiElement>>()!!
+            assertEquals(3, projections.children.size)
+
+            val titleProjection = projections.children[0]
+            assertEquals(Name.INCLUDE, titleProjection.component<Named>()!!.name)
+
+            val titleProjectionFieldRef =
+                (titleProjection.component<HasFieldReference<PsiElement>>()!!.reference) as FromSchema
+            assertEquals(
+                "title",
+                titleProjectionFieldRef.fieldName
+            )
+
+            val titleProjectionValueRef =
+                (titleProjection.component<HasValueReference<PsiElement>>()!!.reference) as Inferred
+            assertEquals(
+                1,
+                titleProjectionValueRef.value
+            )
+
+            val yearProjection = projections.children[1]
+            assertEquals(Name.INCLUDE, yearProjection.component<Named>()!!.name)
+
+            val yearProjectionFieldRef =
+                (yearProjection.component<HasFieldReference<PsiElement>>()!!.reference) as FromSchema
+            assertEquals(
+                "year",
+                yearProjectionFieldRef.fieldName
+            )
+
+            val yearProjectionValueRef =
+                (yearProjection.component<HasValueReference<PsiElement>>()!!.reference) as Inferred
+            assertEquals(
+                1,
+                yearProjectionValueRef.value
+            )
+
+            val authorProjection = projections.children[2]
+            assertEquals(Name.INCLUDE, authorProjection.component<Named>()!!.name)
+
+            val authorProjectionFieldRef =
+                (authorProjection.component<HasFieldReference<PsiElement>>()!!.reference) as FromSchema
+            assertEquals(
+                "author",
+                authorProjectionFieldRef.fieldName
+            )
+
+            val authorProjectionValueRef =
+                (authorProjection.component<HasValueReference<PsiElement>>()!!.reference) as Inferred
+            assertEquals(
+                1,
+                authorProjectionValueRef.value
+            )
+        }
+
+        fun commonAssertionsForExcludeProjection(projectStageNode: Node<PsiElement>) {
+            val named = projectStageNode.component<Named>()!!
+            assertEquals(Name.PROJECT, named.name)
+
+            val projections = projectStageNode.component<HasProjections<PsiElement>>()!!
+            assertEquals(3, projections.children.size)
+
+            val titleProjection = projections.children[0]
+            assertEquals(Name.EXCLUDE, titleProjection.component<Named>()!!.name)
+
+            val titleProjectionFieldRef =
+                (titleProjection.component<HasFieldReference<PsiElement>>()!!.reference) as FromSchema
+            assertEquals(
+                "title",
+                titleProjectionFieldRef.fieldName
+            )
+
+            val titleProjectionValueRef =
+                (titleProjection.component<HasValueReference<PsiElement>>()!!.reference) as Inferred
+            assertEquals(
+                -1,
+                titleProjectionValueRef.value
+            )
+
+            val yearProjection = projections.children[1]
+            assertEquals(Name.EXCLUDE, yearProjection.component<Named>()!!.name)
+
+            val yearProjectionFieldRef =
+                (yearProjection.component<HasFieldReference<PsiElement>>()!!.reference) as FromSchema
+            assertEquals(
+                "year",
+                yearProjectionFieldRef.fieldName
+            )
+
+            val yearProjectionValueRef =
+                (yearProjection.component<HasValueReference<PsiElement>>()!!.reference) as Inferred
+            assertEquals(
+                -1,
+                yearProjectionValueRef.value
+            )
+
+            val authorProjection = projections.children[2]
+            assertEquals(Name.EXCLUDE, authorProjection.component<Named>()!!.name)
+
+            val authorProjectionFieldRef =
+                (authorProjection.component<HasFieldReference<PsiElement>>()!!.reference) as FromSchema
+            assertEquals(
+                "author",
+                authorProjectionFieldRef.fieldName
+            )
+
+            val authorProjectionValueRef =
+                (authorProjection.component<HasValueReference<PsiElement>>()!!.reference) as Inferred
+            assertEquals(
+                -1,
+                authorProjectionValueRef.value
+            )
+        }
+
+        fun commonAssertionsForFieldsProjection(projectStageNode: Node<PsiElement>) {
+            val named = projectStageNode.component<Named>()!!
+            assertEquals(Name.PROJECT, named.name)
+
+            val projections = projectStageNode.component<HasProjections<PsiElement>>()!!
+            assertEquals(4, projections.children.size)
+
+            val titleProjection = projections.children[0]
+            assertEquals(Name.INCLUDE, titleProjection.component<Named>()!!.name)
+
+            val titleProjectionFieldRef =
+                (titleProjection.component<HasFieldReference<PsiElement>>()!!.reference) as FromSchema
+            assertEquals(
+                "title",
+                titleProjectionFieldRef.fieldName
+            )
+
+            val titleProjectionValueRef =
+                (titleProjection.component<HasValueReference<PsiElement>>()!!.reference) as Inferred
+            assertEquals(
+                1,
+                titleProjectionValueRef.value
+            )
+
+            val yearProjection = projections.children[1]
+            assertEquals(Name.INCLUDE, yearProjection.component<Named>()!!.name)
+
+            val yearProjectionFieldRef =
+                (yearProjection.component<HasFieldReference<PsiElement>>()!!.reference) as FromSchema
+            assertEquals(
+                "year",
+                yearProjectionFieldRef.fieldName
+            )
+
+            val yearProjectionValueRef =
+                (yearProjection.component<HasValueReference<PsiElement>>()!!.reference) as Inferred
+            assertEquals(
+                1,
+                yearProjectionValueRef.value
+            )
+
+            val publishedProjection = projections.children[2]
+            assertEquals(Name.EXCLUDE, publishedProjection.component<Named>()!!.name)
+
+            val publishedProjectionFieldRef =
+                (publishedProjection.component<HasFieldReference<PsiElement>>()!!.reference) as FromSchema
+            assertEquals(
+                "published",
+                publishedProjectionFieldRef.fieldName
+            )
+
+            val publishedProjectionValueRef =
+                (publishedProjection.component<HasValueReference<PsiElement>>()!!.reference) as Inferred
+            assertEquals(
+                -1,
+                publishedProjectionValueRef.value
+            )
+
+            val authorProjection = projections.children[3]
+            assertEquals(Name.EXCLUDE, authorProjection.component<Named>()!!.name)
+
+            val authorProjectionFieldRef =
+                (authorProjection.component<HasFieldReference<PsiElement>>()!!.reference) as FromSchema
+            assertEquals(
+                "author",
+                authorProjectionFieldRef.fieldName
+            )
+
+            val authorProjectionValueRef =
+                (authorProjection.component<HasValueReference<PsiElement>>()!!.reference) as Inferred
+            assertEquals(
+                -1,
+                authorProjectionValueRef.value
+            )
+        }
+    }
+}

--- a/packages/mongodb-linting-engine/src/main/kotlin/com/mongodb/jbplugin/linting/FieldCheckingLinter.kt
+++ b/packages/mongodb-linting-engine/src/main/kotlin/com/mongodb/jbplugin/linting/FieldCheckingLinter.kt
@@ -15,7 +15,7 @@ import com.mongodb.jbplugin.mql.adt.Either
 import com.mongodb.jbplugin.mql.components.HasFieldReference
 import com.mongodb.jbplugin.mql.parser.components.NoFieldReference
 import com.mongodb.jbplugin.mql.parser.components.ParsedValueReference
-import com.mongodb.jbplugin.mql.parser.components.allFiltersRecursively
+import com.mongodb.jbplugin.mql.parser.components.allNodesWithSchemaFieldReferences
 import com.mongodb.jbplugin.mql.parser.components.extractValueReference
 import com.mongodb.jbplugin.mql.parser.components.knownCollection
 import com.mongodb.jbplugin.mql.parser.components.schemaFieldReference
@@ -112,7 +112,7 @@ object FieldCheckingLinter {
                         .map { toValueMismatchWarning(collectionSchema, it) }
                         .mapError { NoFieldReference }
 
-                    val allFieldAndValueReferencesParser = allFiltersRecursively<S>().mapMany(
+                    val allFieldAndValueReferencesParser = allNodesWithSchemaFieldReferences<S>().mapMany(
                         first(
                             extractTypeMismatchWarning,
                             extractFieldExistenceWarning,

--- a/packages/mongodb-linting-engine/src/test/kotlin/com/mongodb/jbplugin/linting/FieldCheckingLinterTest.kt
+++ b/packages/mongodb-linting-engine/src/test/kotlin/com/mongodb/jbplugin/linting/FieldCheckingLinterTest.kt
@@ -3,9 +3,11 @@ package com.mongodb.jbplugin.linting
 import com.mongodb.jbplugin.accessadapter.MongoDbReadModelProvider
 import com.mongodb.jbplugin.accessadapter.slice.GetCollectionSchema
 import com.mongodb.jbplugin.mql.*
+import com.mongodb.jbplugin.mql.components.HasAggregation
 import com.mongodb.jbplugin.mql.components.HasCollectionReference
 import com.mongodb.jbplugin.mql.components.HasFieldReference
 import com.mongodb.jbplugin.mql.components.HasFilter
+import com.mongodb.jbplugin.mql.components.HasProjections
 import com.mongodb.jbplugin.mql.components.HasValueReference
 import com.mongodb.jbplugin.mql.components.Name
 import com.mongodb.jbplugin.mql.components.Named
@@ -253,5 +255,222 @@ class FieldCheckingLinterTest {
         assertInstanceOf(FieldCheckWarning.FieldValueTypeMismatch::class.java, result.warnings[0])
         val warning = result.warnings[0] as FieldCheckWarning.FieldValueTypeMismatch
         assertEquals("myInt", warning.field)
+    }
+
+    @Test
+    fun `warns about the referenced fields in an Aggregation#match not in the specified collection`() {
+        val readModelProvider = mock<MongoDbReadModelProvider<Unit>>()
+        val collectionNamespace = Namespace("database", "collection")
+
+        `when`(readModelProvider.slice(any(), any<GetCollectionSchema.Slice>())).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    collectionNamespace,
+                    BsonObject(
+                        mapOf(
+                            "myString" to BsonString,
+                            "myInt" to BsonInt32,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val result =
+            FieldCheckingLinter.lintQuery(
+                Unit,
+                readModelProvider,
+                Node(
+                    null,
+                    listOf(
+                        HasCollectionReference(
+                            HasCollectionReference.Known(null, null, collectionNamespace)
+                        ),
+                        HasAggregation(
+                            children = listOf(
+                                Node(
+                                    null,
+                                    listOf(
+                                        Named(Name.MATCH),
+                                        HasFilter(
+                                            listOf(
+                                                Node(
+                                                    null,
+                                                    listOf(
+                                                        HasFieldReference(
+                                                            HasFieldReference.FromSchema(
+                                                                null,
+                                                                "myString"
+                                                            )
+                                                        )
+                                                    )
+                                                ),
+                                                Node(
+                                                    null,
+                                                    listOf(
+                                                        HasFieldReference(
+                                                            HasFieldReference.FromSchema(
+                                                                null,
+                                                                "myBoolean"
+                                                            )
+                                                        )
+                                                    )
+                                                ),
+                                            ),
+                                        ),
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                ),
+            )
+
+        assertEquals(1, result.warnings.size)
+        assertInstanceOf(FieldCheckWarning.FieldDoesNotExist::class.java, result.warnings[0])
+        val warning = result.warnings[0] as FieldCheckWarning.FieldDoesNotExist
+        assertEquals("myBoolean", warning.field)
+    }
+
+    @Test
+    fun `warns about a value not matching the type of underlying field in Aggregation#match`() {
+        val readModelProvider = mock<MongoDbReadModelProvider<Unit>>()
+        val collectionNamespace = Namespace("database", "collection")
+
+        `when`(readModelProvider.slice(any(), any<GetCollectionSchema.Slice>())).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    collectionNamespace,
+                    BsonObject(
+                        mapOf(
+                            "myString" to BsonString,
+                            "myInt" to BsonInt32,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val result =
+            FieldCheckingLinter.lintQuery(
+                Unit,
+                readModelProvider,
+                Node(
+                    null,
+                    listOf(
+                        HasCollectionReference(
+                            HasCollectionReference.Known(null, null, collectionNamespace)
+                        ),
+                        HasAggregation(
+                            listOf(
+                                Node(
+                                    null,
+                                    listOf(
+                                        Named(Name.MATCH),
+                                        HasFilter(
+                                            listOf(
+                                                Node(
+                                                    null,
+                                                    listOf(
+                                                        HasFieldReference(
+                                                            HasFieldReference.FromSchema(
+                                                                null,
+                                                                "myInt"
+                                                            )
+                                                        ),
+                                                        HasValueReference(
+                                                            HasValueReference.Constant(
+                                                                null,
+                                                                null,
+                                                                BsonNull
+                                                            )
+                                                        )
+                                                    )
+                                                ),
+                                            ),
+                                        ),
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                ),
+            )
+
+        assertEquals(1, result.warnings.size)
+        assertInstanceOf(FieldCheckWarning.FieldValueTypeMismatch::class.java, result.warnings[0])
+        val warning = result.warnings[0] as FieldCheckWarning.FieldValueTypeMismatch
+        assertEquals("myInt", warning.field)
+    }
+
+    @Test
+    fun `warns about the referenced fields in an Aggregation#project not in the specified collection`() {
+        val readModelProvider = mock<MongoDbReadModelProvider<Unit>>()
+        val collectionNamespace = Namespace("database", "collection")
+
+        `when`(readModelProvider.slice(any(), any<GetCollectionSchema.Slice>())).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    collectionNamespace,
+                    BsonObject(
+                        mapOf(
+                            "myInt" to BsonInt32,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val result =
+            FieldCheckingLinter.lintQuery(
+                Unit,
+                readModelProvider,
+                Node(
+                    null,
+                    listOf(
+                        HasCollectionReference(
+                            HasCollectionReference.Known(null, null, collectionNamespace)
+                        ),
+                        HasAggregation(
+                            children = listOf(
+                                Node(
+                                    null,
+                                    listOf(
+                                        Named(Name.PROJECT),
+                                        HasProjections(
+                                            listOf(
+                                                Node(
+                                                    null,
+                                                    listOf(
+                                                        Named(Name.INCLUDE),
+                                                        HasFieldReference(
+                                                            HasFieldReference.FromSchema(
+                                                                null,
+                                                                "myBoolean"
+                                                            )
+                                                        ),
+                                                        HasValueReference(
+                                                            HasValueReference.Inferred(
+                                                                null,
+                                                                1,
+                                                                BsonInt32
+                                                            )
+                                                        )
+                                                    )
+                                                )
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                ),
+            )
+
+        assertEquals(1, result.warnings.size)
+        assertInstanceOf(FieldCheckWarning.FieldDoesNotExist::class.java, result.warnings[0])
+        val warning = result.warnings[0] as FieldCheckWarning.FieldDoesNotExist
+        assertEquals("myBoolean", warning.field)
     }
 }

--- a/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/Node.kt
+++ b/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/Node.kt
@@ -58,6 +58,8 @@ data class Node<S>(
 
     inline fun <reified C : Component> components(): List<C> = components.filterIsInstance<C>()
 
+    fun componentsWithChildren(): List<HasChildren<*>> = components.filterIsInstance<HasChildren<*>>()
+
     inline fun <reified C : Component> hasComponent(): Boolean = component<C>() != null
 
     fun withTargetCluster(cluster: HasTargetCluster): Node<S> = copy(

--- a/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/Node.kt
+++ b/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/Node.kt
@@ -58,7 +58,7 @@ data class Node<S>(
 
     inline fun <reified C : Component> components(): List<C> = components.filterIsInstance<C>()
 
-    fun componentsWithChildren(): List<HasChildren<*>> = components.filterIsInstance<HasChildren<*>>()
+    fun componentsWithChildren(): List<HasChildren<S>> = components.filterIsInstance<HasChildren<S>>()
 
     inline fun <reified C : Component> hasComponent(): Boolean = component<C>() != null
 

--- a/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/components/HasProjections.kt
+++ b/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/components/HasProjections.kt
@@ -1,0 +1,8 @@
+package com.mongodb.jbplugin.mql.components
+
+import com.mongodb.jbplugin.mql.HasChildren
+import com.mongodb.jbplugin.mql.Node
+
+data class HasProjections<S>(
+    override val children: List<Node<S>>
+) : HasChildren<S>

--- a/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/components/Named.kt
+++ b/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/components/Named.kt
@@ -49,6 +49,9 @@ enum class Name(val canonical: String) {
     TYPE("type"),
     UNSET("unset"),
     MATCH("match"),
+    PROJECT("project"),
+    INCLUDE("include"),
+    EXCLUDE("exclude"),
     UNKNOWN("<unknown operator>"),
     ;
 

--- a/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/components/HasFieldReference.kt
+++ b/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/components/HasFieldReference.kt
@@ -1,11 +1,14 @@
 package com.mongodb.jbplugin.mql.parser.components
 
+import com.mongodb.jbplugin.mql.HasChildren
 import com.mongodb.jbplugin.mql.Node
 import com.mongodb.jbplugin.mql.adt.Either
 import com.mongodb.jbplugin.mql.components.HasFieldReference
 import com.mongodb.jbplugin.mql.parser.Parser
 
 data object NoFieldReference
+
+data object NoFieldReferences
 
 inline fun <reified T : HasFieldReference.FieldReference<S>, S> fieldReference(): Parser<Node<S>, NoFieldReference, T> {
     return { input ->
@@ -18,3 +21,27 @@ inline fun <reified T : HasFieldReference.FieldReference<S>, S> fieldReference()
 }
 
 fun <S> schemaFieldReference() = fieldReference<HasFieldReference.FromSchema<S>, S>()
+
+fun <S> allNodesWithSchemaFieldReferences(): Parser<Node<S>, NoFieldReferences, List<Node<S>>> {
+    return { input ->
+        fun gatherSchemaFieldReferenceNodes(node: Node<S>): List<Node<S>> {
+            val isSchemaFieldReference = node.component<HasFieldReference<S>>()?.reference is HasFieldReference.FromSchema<S>
+
+            val currentNode = if (isSchemaFieldReference) listOf(node) else emptyList()
+
+            val childNodes = node.componentsWithChildren()
+                .flatMap { (it as HasChildren<S>).children }
+                .flatMap(::gatherSchemaFieldReferenceNodes)
+
+            return currentNode + childNodes
+        }
+
+        val result = gatherSchemaFieldReferenceNodes(input)
+
+        if (result.isEmpty()) {
+            Either.left(NoFieldReferences)
+        } else {
+            Either.right(result)
+        }
+    }
+}


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER-IF-ANY>

  eg. fix(type-hint): infer type of a constant for type checking INTELLIJ-1111
-->

## Description
Includes:
- Parsing of $project built with Aggregates.project, limited to, as defined in scope:
  - Projections.include
  - Projections.exclude
  - Projections.fields
- Autocomplete support for fields in Projections.include, Projections.exclude and Projections.fields
- Linter inspections for field existence and type checks in Projections

<!--- Describe your changes in detail so reviewers have enough content on what this PR aims to achieve -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist

- [ ] New tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
- [ ] Changelog is updated accordingly.
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement).

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->