### PR TITLE
feat: adds support for parsing Aggregates.sort stage INTELLIJ-127

### DIFF
--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/JavaDriverCompletionContributorTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/JavaDriverCompletionContributorTest.kt
@@ -543,4 +543,201 @@ public class Repository {
             },
         )
     }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Projections;
+import com.mongodb.client.model.Sorts;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import java.util.List;
+import static com.mongodb.client.model.Filters.*;
+import static com.mongodb.client.model.Updates.*;
+
+public class Repository {
+    private final MongoClient client;
+
+    public Repository(MongoClient client) {
+        this.client = client;
+    }
+
+    public void exampleFind() {
+        client.getDatabase("myDatabase").getCollection("myCollection")
+                .aggregate(List.of(
+                    Aggregates.sort(
+                        Sorts.ascending("<caret>")
+                    )                
+                ));
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Sorts#ascending of an Aggregates#sort stage`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        fixture.specifyDialect(JavaDriverDialect)
+
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        val namespace = Namespace("myDatabase", "myCollection")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Projections;
+import com.mongodb.client.model.Sorts;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import java.util.List;
+import static com.mongodb.client.model.Filters.*;
+import static com.mongodb.client.model.Updates.*;
+
+public class Repository {
+    private final MongoClient client;
+
+    public Repository(MongoClient client) {
+        this.client = client;
+    }
+
+    public void exampleFind() {
+        client.getDatabase("myDatabase").getCollection("myCollection")
+                .aggregate(List.of(
+                    Aggregates.sort(
+                        Sorts.descending("<caret>")
+                    )                
+                ));
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Sorts#descending of an Aggregates#sort stage`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        fixture.specifyDialect(JavaDriverDialect)
+
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        val namespace = Namespace("myDatabase", "myCollection")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Projections;
+import com.mongodb.client.model.Sorts;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import java.util.List;
+import static com.mongodb.client.model.Filters.*;
+import static com.mongodb.client.model.Updates.*;
+
+public class Repository {
+    private final MongoClient client;
+
+    public Repository(MongoClient client) {
+        this.client = client;
+    }
+
+    public void exampleFind() {
+        client.getDatabase("myDatabase").getCollection("myCollection")
+                .aggregate(List.of(
+                    Aggregates.sort(
+                        Sorts.orderBy(
+                            Sorts.descending("<caret>")
+                        )
+                    )                
+                ));
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Sorts#orderBy of an Aggregates#sort stage`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        fixture.specifyDialect(JavaDriverDialect)
+
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        val namespace = Namespace("myDatabase", "myCollection")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+    }
 }

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/JavaDriverMongoDbAutocompletionPopupHandlerTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/JavaDriverMongoDbAutocompletionPopupHandlerTest.kt
@@ -552,4 +552,204 @@ public class Repository {
             },
         )
     }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Projections;
+import com.mongodb.client.model.Sorts;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import java.util.List;
+import static com.mongodb.client.model.Filters.*;
+import static com.mongodb.client.model.Updates.*;
+
+public class Repository {
+    private final MongoClient client;
+
+    public Repository(MongoClient client) {
+        this.client = client;
+    }
+
+    public void exampleFind() {
+        client.getDatabase("myDatabase").getCollection("myCollection")
+                .aggregate(List.of(
+                    Aggregates.sort(
+                        Sorts.ascending(<caret>)
+                    )                
+                ));
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Sorts#ascending of an Aggregates#sort stage`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        fixture.specifyDialect(JavaDriverDialect)
+
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        val namespace = Namespace("myDatabase", "myCollection")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        fixture.type('"')
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Projections;
+import com.mongodb.client.model.Sorts;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import java.util.List;
+import static com.mongodb.client.model.Filters.*;
+import static com.mongodb.client.model.Updates.*;
+
+public class Repository {
+    private final MongoClient client;
+
+    public Repository(MongoClient client) {
+        this.client = client;
+    }
+
+    public void exampleFind() {
+        client.getDatabase("myDatabase").getCollection("myCollection")
+                .aggregate(List.of(
+                    Aggregates.sort(
+                        Sorts.descending(<caret>)
+                    )                
+                ));
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Sorts#descending of an Aggregates#sort stage`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        fixture.specifyDialect(JavaDriverDialect)
+
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        val namespace = Namespace("myDatabase", "myCollection")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        fixture.type('"')
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Projections;
+import com.mongodb.client.model.Sorts;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import java.util.List;
+import static com.mongodb.client.model.Filters.*;
+import static com.mongodb.client.model.Updates.*;
+
+public class Repository {
+    private final MongoClient client;
+
+    public Repository(MongoClient client) {
+        this.client = client;
+    }
+
+    public void exampleFind() {
+        client.getDatabase("myDatabase").getCollection("myCollection")
+                .aggregate(List.of(
+                    Aggregates.sort(
+                        Sorts.orderBy(
+                            Sorts.descending(<caret>)
+                        )
+                    )                
+                ));
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Sorts#orderBy of an Aggregates#sort stage`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        fixture.specifyDialect(JavaDriverDialect)
+
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        val namespace = Namespace("myDatabase", "myCollection")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        fixture.type('"')
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+    }
 }

--- a/packages/jetbrains-plugin/src/test/resources/project-fixtures/basic-java-project-with-mongodb/src/main/java/alt/mongodb/javadriver/JavaDriverRepository.java
+++ b/packages/jetbrains-plugin/src/test/resources/project-fixtures/basic-java-project-with-mongodb/src/main/java/alt/mongodb/javadriver/JavaDriverRepository.java
@@ -4,6 +4,7 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.client.model.Aggregates;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Projections;
+import com.mongodb.client.model.Sorts;
 import org.bson.Document;
 
 import java.util.ArrayList;
@@ -57,6 +58,11 @@ public class JavaDriverRepository {
                     Aggregates.project(
                         Projections.fields(
                             Projections.include("year", "plot")
+                        )
+                    ),
+                    Aggregates.sort(
+                        Sorts.orderBy(
+                            Sorts.ascending("asd", "qwe")
                         )
                     )
                 )

--- a/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParser.kt
+++ b/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParser.kt
@@ -224,7 +224,8 @@ object JavaDriverDialectParser : DialectParser<PsiElement> {
         val containingClass = methodCall.resolveMethod()?.containingClass ?: return false
 
         return containingClass.qualifiedName == AGGREGATES_FQN ||
-            containingClass.qualifiedName == PROJECTIONS_FQN
+            containingClass.qualifiedName == PROJECTIONS_FQN ||
+            containingClass.qualifiedName == SORTS_FQN
     }
 
     private fun resolveToFiltersCall(element: PsiElement): PsiMethodCallExpression? {

--- a/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParser.kt
+++ b/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParser.kt
@@ -514,13 +514,12 @@ object JavaDriverDialectParser : DialectParser<PsiElement> {
                                 HasValueReference(
                                     reference = HasValueReference.Inferred(
                                         source = it,
-                                        value = if (
-                                            methodName == Name.INCLUDE ||
-                                            methodName == Name.ASCENDING
-                                        ) {
-                                            1
-                                        } else {
-                                            -1
+                                        value = when (methodName) {
+                                            Name.INCLUDE,
+                                            Name.ASCENDING -> 1
+                                            Name.EXCLUDE -> 0
+                                            // Else is just the descending case
+                                            else -> -1
                                         },
                                         type = BsonInt32,
                                     )

--- a/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParser.kt
+++ b/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParser.kt
@@ -414,16 +414,26 @@ object JavaDriverDialectParser : DialectParser<PsiElement> {
 
         when (stageCallMethod.name) {
             "match" -> {
+                val nodeWithFilters: (List<Node<PsiElement>>) -> Node<PsiElement> =
+                    { filter ->
+                        Node(
+                            source = stageCall,
+                            components = listOf(
+                                Named(Name.MATCH),
+                                HasFilter(filter)
+                            )
+                        )
+                    }
                 // There will only be one argument to Aggregates.match and that has to be the Bson
                 // filters. We retrieve that and resolve the values.
                 val filterExpression = stageCall.argumentList.expressions.getOrNull(0)
-                    ?: return null
+                    ?: return nodeWithFilters(emptyList())
 
                 val resolvedFilterExpression = resolveToFiltersCall(filterExpression)
-                    ?: return null
+                    ?: return nodeWithFilters(emptyList())
 
                 val parsedFilter = parseFilterExpression(resolvedFilterExpression)
-                    ?: return null
+                    ?: return nodeWithFilters(emptyList())
 
                 return Node(
                     source = stageCall,

--- a/packages/mongodb-dialects/java-driver/src/test/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/aggregationparser/MatchStageParserTest.kt
+++ b/packages/mongodb-dialects/java-driver/src/test/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/aggregationparser/MatchStageParserTest.kt
@@ -43,6 +43,45 @@ public final class Aggregation {
 
     public AggregateIterable<Document> findBookById(ObjectId id) {
         return this.collection.aggregate(List.of(
+            Aggregates.match()
+        ));
+    }
+}
+        """,
+    )
+    fun `(Aggregates#match call) should be able to parse an empty call`(psiFile: PsiFile) {
+        val aggregate = psiFile.getQueryAtMethod("Aggregation", "findBookById")
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(hasAggregation?.children?.size, 1)
+        val matchStageNode = hasAggregation?.children?.first()!!
+        assertEquals(Name.MATCH, matchStageNode.component<Named>()!!.name)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+
+    public AggregateIterable<Document> findBookById(ObjectId id) {
+        return this.collection.aggregate(List.of(
             Aggregates.match(
                 Filters.eq("name", "MongoDB")
             )

--- a/packages/mongodb-dialects/java-driver/src/test/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/aggregationparser/ProjectStageParserTest.kt
+++ b/packages/mongodb-dialects/java-driver/src/test/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/aggregationparser/ProjectStageParserTest.kt
@@ -1202,7 +1202,7 @@ public final class Aggregation {
             val titleProjectionValueRef =
                 (titleProjection.component<HasValueReference<PsiElement>>()!!.reference) as Inferred
             assertEquals(
-                -1,
+                0,
                 titleProjectionValueRef.value
             )
 
@@ -1219,7 +1219,7 @@ public final class Aggregation {
             val yearProjectionValueRef =
                 (yearProjection.component<HasValueReference<PsiElement>>()!!.reference) as Inferred
             assertEquals(
-                -1,
+                0,
                 yearProjectionValueRef.value
             )
 
@@ -1236,7 +1236,7 @@ public final class Aggregation {
             val authorProjectionValueRef =
                 (authorProjection.component<HasValueReference<PsiElement>>()!!.reference) as Inferred
             assertEquals(
-                -1,
+                0,
                 authorProjectionValueRef.value
             )
         }
@@ -1295,7 +1295,7 @@ public final class Aggregation {
             val publishedProjectionValueRef =
                 (publishedProjection.component<HasValueReference<PsiElement>>()!!.reference) as Inferred
             assertEquals(
-                -1,
+                0,
                 publishedProjectionValueRef.value
             )
 
@@ -1312,7 +1312,7 @@ public final class Aggregation {
             val authorProjectionValueRef =
                 (authorProjection.component<HasValueReference<PsiElement>>()!!.reference) as Inferred
             assertEquals(
-                -1,
+                0,
                 authorProjectionValueRef.value
             )
         }

--- a/packages/mongodb-dialects/java-driver/src/test/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/aggregationparser/SortStageParserTest.kt
+++ b/packages/mongodb-dialects/java-driver/src/test/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/aggregationparser/SortStageParserTest.kt
@@ -1,0 +1,1324 @@
+package com.mongodb.jbplugin.dialects.javadriver.glossary.aggregationparser
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.mongodb.jbplugin.dialects.javadriver.IntegrationTest
+import com.mongodb.jbplugin.dialects.javadriver.ParsingTest
+import com.mongodb.jbplugin.dialects.javadriver.getQueryAtMethod
+import com.mongodb.jbplugin.dialects.javadriver.glossary.JavaDriverDialect
+import com.mongodb.jbplugin.mql.Node
+import com.mongodb.jbplugin.mql.components.HasAggregation
+import com.mongodb.jbplugin.mql.components.HasFieldReference
+import com.mongodb.jbplugin.mql.components.HasFieldReference.FromSchema
+import com.mongodb.jbplugin.mql.components.HasSorts
+import com.mongodb.jbplugin.mql.components.HasValueReference
+import com.mongodb.jbplugin.mql.components.HasValueReference.Inferred
+import com.mongodb.jbplugin.mql.components.Name
+import com.mongodb.jbplugin.mql.components.Named
+import org.junit.jupiter.api.Assertions.assertEquals
+
+@IntegrationTest
+class SortStageParserTest {
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        return this.collection.aggregate(List.of(
+            Aggregates.sort()
+        ));
+    }
+}
+      """
+    )
+    fun `should be able to parse an empty sort call`(psiFile: PsiFile) {
+        val aggregate = psiFile.getQueryAtMethod("Aggregation", "getAllBookTitles")
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val sortStageNode = hasAggregation?.children?.get(0)!!
+
+        val named = sortStageNode.component<Named>()!!
+        assertEquals(Name.SORT, named.name)
+
+        assertEquals(0, sortStageNode.component<HasSorts<PsiElement>>()!!.children.size)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Sorts;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String yearField = "year"; 
+        return this.collection.aggregate(List.of(
+            Aggregates.sort(
+                Sorts.ascending("title", yearField, getAuthorField())
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Sorts#ascending - should be able to parse with varargs`(psiFile: PsiFile) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val sortStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForAscendingSort(sortStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Sorts;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String yearField = "year";
+        return this.collection.aggregate(List.of(
+            Aggregates.sort(
+                Sorts.ascending(
+                    List.of("title", yearField, getAuthorField())
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Sorts#ascending - should be able to parse with List#of`(psiFile: PsiFile) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val sortStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForAscendingSort(sortStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Sorts;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String yearField = "year";
+        List<String> projectedFields = List.of("title", yearField, getAuthorField());
+        return this.collection.aggregate(List.of(
+            Aggregates.sort(
+                Sorts.ascending(
+                    projectedFields
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Sorts#ascending - should be able to parse with List#of when the list is a variable`(
+        psiFile: PsiFile
+    ) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val sortStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForAscendingSort(sortStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Sorts;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+    
+    private List<String> getProjectedFields() {
+        String yearField = "year";
+        return List.of("title", yearField, getAuthorField());
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        return this.collection.aggregate(List.of(
+            Aggregates.sort(
+                Sorts.ascending(
+                    getProjectedFields()
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Sorts#ascending - should be able to parse with List#of when the list is from a method call`(
+        psiFile: PsiFile
+    ) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val sortStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForAscendingSort(sortStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Sorts;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+import java.util.Arrays;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String yearField = "year";
+        return this.collection.aggregate(List.of(
+            Aggregates.sort(
+                Sorts.ascending(
+                    Arrays.asList("title", yearField, getAuthorField())
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Sorts#ascending - should be able to parse with Arrays#asList`(psiFile: PsiFile) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val sortStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForAscendingSort(sortStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Sorts;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String yearField = "year";
+        List<String> projectedFields = Arrays.asList("title", yearField, getAuthorField());
+        return this.collection.aggregate(List.of(
+            Aggregates.sort(
+                Sorts.ascending(
+                    projectedFields
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Sorts#ascending - should be able to parse with Arrays#asList when the list is a variable`(
+        psiFile: PsiFile
+    ) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val sortStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForAscendingSort(sortStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Sorts;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+    
+    private List<String> getProjectedFields() {
+        String yearField = "year";
+        return Arrays.asList("title", yearField, getAuthorField());
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        return this.collection.aggregate(List.of(
+            Aggregates.sort(
+                Sorts.ascending(
+                    getProjectedFields()
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Sorts#ascending - should be able to parse with Arrays#asList when the list is from a method call`(
+        psiFile: PsiFile
+    ) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val sortStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForAscendingSort(sortStageNode)
+    }
+
+    // ////////////////////////////////////////////////////////////////////////
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Sorts;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String yearField = "year"; 
+        return this.collection.aggregate(List.of(
+            Aggregates.sort(
+                Sorts.descending("title", yearField, getAuthorField())
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Sorts#descending - should be able to parse with varargs`(psiFile: PsiFile) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val sortStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForDescendingSort(sortStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Sorts;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String yearField = "year";
+        return this.collection.aggregate(List.of(
+            Aggregates.sort(
+                Sorts.descending(
+                    List.of("title", yearField, getAuthorField())
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Sorts#descending - should be able to parse with List#of`(psiFile: PsiFile) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val sortStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForDescendingSort(sortStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Sorts;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String yearField = "year";
+        List<String> projectedFields = List.of("title", yearField, getAuthorField());
+        return this.collection.aggregate(List.of(
+            Aggregates.sort(
+                Sorts.descending(
+                    projectedFields
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Sorts#descending - should be able to parse with List#of when the list is a variable`(
+        psiFile: PsiFile
+    ) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val sortStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForDescendingSort(sortStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Sorts;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+    
+    private List<String> getProjectedFields() {
+        String yearField = "year";
+        return List.of("title", yearField, getAuthorField());
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        return this.collection.aggregate(List.of(
+            Aggregates.sort(
+                Sorts.descending(
+                    getProjectedFields()
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Sorts#descending - should be able to parse with List#of when the list is from a method call`(
+        psiFile: PsiFile
+    ) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val sortStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForDescendingSort(sortStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Sorts;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+import java.util.Arrays;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String yearField = "year";
+        return this.collection.aggregate(List.of(
+            Aggregates.sort(
+                Sorts.descending(
+                    Arrays.asList("title", yearField, getAuthorField())
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Sorts#descending - should be able to parse with Arrays#asList`(psiFile: PsiFile) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val sortStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForDescendingSort(sortStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Sorts;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String yearField = "year";
+        List<String> projectedFields = Arrays.asList("title", yearField, getAuthorField());
+        return this.collection.aggregate(List.of(
+            Aggregates.sort(
+                Sorts.descending(
+                    projectedFields
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Sorts#descending - should be able to parse with Arrays#asList when the list is a variable`(
+        psiFile: PsiFile
+    ) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val sortStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForDescendingSort(sortStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Sorts;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+    
+    private List<String> getProjectedFields() {
+        String yearField = "year";
+        return Arrays.asList("title", yearField, getAuthorField());
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        return this.collection.aggregate(List.of(
+            Aggregates.sort(
+                Sorts.descending(
+                    getProjectedFields()
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Sorts#descending - should be able to parse with Arrays#asList when the list is from a method call`(
+        psiFile: PsiFile
+    ) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val sortStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForDescendingSort(sortStageNode)
+    }
+
+    // ////////////////////////////////////////////////////
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Sorts;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+    
+    private Bson getThirdSort() {
+        return Sorts.descending(Arrays.asList("published", getAuthorField()));
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String yearField = "year";
+        Bson secondSort = Sorts.ascending(List.of(yearField));
+        return this.collection.aggregate(List.of(
+            Aggregates.sort(
+                Sorts.orderBy(
+                    Sorts.ascending("title"),
+                    secondSort,
+                    getThirdSort()
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Sort#orderBy - should be able to parse with varargs`(psiFile: PsiFile) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val sortStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForOrderBySort(sortStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Sorts;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+    
+    private Bson getThirdSort() {
+        return Sorts.descending(Arrays.asList("published", getAuthorField()));
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String yearField = "year";
+        Bson secondSort = Sorts.ascending(List.of(yearField));
+        return this.collection.aggregate(List.of(
+            Aggregates.sort(
+                Sorts.orderBy(
+                    List.of(
+                        Sorts.ascending("title"),
+                        secondSort,
+                        getThirdSort()
+                    )
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Sort#orderBy - should be able to parse with List#of`(psiFile: PsiFile) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val sortStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForOrderBySort(sortStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Sorts;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.bson.conversions.Bson;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+    
+    private Bson getThirdSort() {
+        return Sorts.descending(Arrays.asList("published", getAuthorField()));
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String yearField = "year";
+        Bson secondSort = Sorts.ascending(List.of(yearField));
+        List<Bson> sorts = List.of(
+            Sorts.ascending("title"),
+            secondSort,
+            getThirdSort()
+        );
+        return this.collection.aggregate(List.of(
+            Aggregates.sort(
+                Sorts.orderBy(
+                    sorts
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Sort#orderBy - should be able to parse with List#of when the list is a variable`(
+        psiFile: PsiFile
+    ) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val sortStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForOrderBySort(sortStageNode)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Sorts;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.bson.conversions.Bson;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+    
+    private String getAuthorField() {
+        return "author";
+    }
+    
+    private Bson getThirdSort() {
+        return Sorts.descending(Arrays.asList("published", getAuthorField()));
+    }
+    
+    private List<Bson> getSorts() {
+        String yearField = "year";
+        Bson secondSort = Sorts.ascending(List.of(yearField));
+        return List.of(
+            Sorts.ascending("title"),
+            secondSort,
+            getThirdSort()
+        );
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        return this.collection.aggregate(List.of(
+            Aggregates.sort(
+                Sorts.orderBy(
+                    getSorts()
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `Sort#orderBy - should be able to parse with List#of when the list comes from a method call`(
+        psiFile: PsiFile
+    ) {
+        val aggregate = psiFile.getQueryAtMethod(
+            "Aggregation",
+            "getAllBookTitles"
+        )
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val sortStageNode = hasAggregation?.children?.get(0)!!
+
+        commonAssertionsForOrderBySort(sortStageNode)
+    }
+
+    companion object {
+        fun commonAssertionsForAscendingSort(sortStageNode: Node<PsiElement>) {
+            val named = sortStageNode.component<Named>()!!
+            assertEquals(Name.SORT, named.name)
+
+            val sorts = sortStageNode.component<HasSorts<PsiElement>>()!!
+            assertEquals(3, sorts.children.size)
+
+            val titleSort = sorts.children[0]
+            assertEquals(Name.ASCENDING, titleSort.component<Named>()!!.name)
+
+            val titleSortFieldRef =
+                (titleSort.component<HasFieldReference<PsiElement>>()!!.reference) as FromSchema
+            assertEquals(
+                "title",
+                titleSortFieldRef.fieldName
+            )
+
+            val titleSortValueRef =
+                (titleSort.component<HasValueReference<PsiElement>>()!!.reference) as Inferred
+            assertEquals(
+                1,
+                titleSortValueRef.value
+            )
+
+            val yearSort = sorts.children[1]
+            assertEquals(Name.ASCENDING, yearSort.component<Named>()!!.name)
+
+            val yearSortFieldRef =
+                (yearSort.component<HasFieldReference<PsiElement>>()!!.reference) as FromSchema
+            assertEquals(
+                "year",
+                yearSortFieldRef.fieldName
+            )
+
+            val yearSortValueRef =
+                (yearSort.component<HasValueReference<PsiElement>>()!!.reference) as Inferred
+            assertEquals(
+                1,
+                yearSortValueRef.value
+            )
+
+            val authorSort = sorts.children[2]
+            assertEquals(Name.ASCENDING, authorSort.component<Named>()!!.name)
+
+            val authorSortFieldRef =
+                (authorSort.component<HasFieldReference<PsiElement>>()!!.reference) as FromSchema
+            assertEquals(
+                "author",
+                authorSortFieldRef.fieldName
+            )
+
+            val authorSortValueRef =
+                (authorSort.component<HasValueReference<PsiElement>>()!!.reference) as Inferred
+            assertEquals(
+                1,
+                authorSortValueRef.value
+            )
+        }
+
+        fun commonAssertionsForDescendingSort(sortStageNode: Node<PsiElement>) {
+            val named = sortStageNode.component<Named>()!!
+            assertEquals(Name.SORT, named.name)
+
+            val sorts = sortStageNode.component<HasSorts<PsiElement>>()!!
+            assertEquals(3, sorts.children.size)
+
+            val titleSort = sorts.children[0]
+            assertEquals(Name.DESCENDING, titleSort.component<Named>()!!.name)
+
+            val titleSortFieldRef =
+                (titleSort.component<HasFieldReference<PsiElement>>()!!.reference) as FromSchema
+            assertEquals(
+                "title",
+                titleSortFieldRef.fieldName
+            )
+
+            val titleSortValueRef =
+                (titleSort.component<HasValueReference<PsiElement>>()!!.reference) as Inferred
+            assertEquals(
+                -1,
+                titleSortValueRef.value
+            )
+
+            val yearSort = sorts.children[1]
+            assertEquals(Name.DESCENDING, yearSort.component<Named>()!!.name)
+
+            val yearSortFieldRef =
+                (yearSort.component<HasFieldReference<PsiElement>>()!!.reference) as FromSchema
+            assertEquals(
+                "year",
+                yearSortFieldRef.fieldName
+            )
+
+            val yearSortValueRef =
+                (yearSort.component<HasValueReference<PsiElement>>()!!.reference) as Inferred
+            assertEquals(
+                -1,
+                yearSortValueRef.value
+            )
+
+            val authorSort = sorts.children[2]
+            assertEquals(Name.DESCENDING, authorSort.component<Named>()!!.name)
+
+            val authorSortFieldRef =
+                (authorSort.component<HasFieldReference<PsiElement>>()!!.reference) as FromSchema
+            assertEquals(
+                "author",
+                authorSortFieldRef.fieldName
+            )
+
+            val authorSortValueRef =
+                (authorSort.component<HasValueReference<PsiElement>>()!!.reference) as Inferred
+            assertEquals(
+                -1,
+                authorSortValueRef.value
+            )
+        }
+
+        fun commonAssertionsForOrderBySort(sortStageNode: Node<PsiElement>) {
+            val named = sortStageNode.component<Named>()!!
+            assertEquals(Name.SORT, named.name)
+
+            val sorts = sortStageNode.component<HasSorts<PsiElement>>()!!
+            assertEquals(4, sorts.children.size)
+
+            val titleSort = sorts.children[0]
+            assertEquals(Name.ASCENDING, titleSort.component<Named>()!!.name)
+
+            val titleSortFieldRef =
+                (titleSort.component<HasFieldReference<PsiElement>>()!!.reference) as FromSchema
+            assertEquals(
+                "title",
+                titleSortFieldRef.fieldName
+            )
+
+            val titleSortValueRef =
+                (titleSort.component<HasValueReference<PsiElement>>()!!.reference) as Inferred
+            assertEquals(
+                1,
+                titleSortValueRef.value
+            )
+
+            val yearSort = sorts.children[1]
+            assertEquals(Name.ASCENDING, yearSort.component<Named>()!!.name)
+
+            val yearSortFieldRef =
+                (yearSort.component<HasFieldReference<PsiElement>>()!!.reference) as FromSchema
+            assertEquals(
+                "year",
+                yearSortFieldRef.fieldName
+            )
+
+            val yearSortValueRef =
+                (yearSort.component<HasValueReference<PsiElement>>()!!.reference) as Inferred
+            assertEquals(
+                1,
+                yearSortValueRef.value
+            )
+
+            val publishedSort = sorts.children[2]
+            assertEquals(Name.DESCENDING, publishedSort.component<Named>()!!.name)
+
+            val publishedSortFieldRef =
+                (publishedSort.component<HasFieldReference<PsiElement>>()!!.reference) as FromSchema
+            assertEquals(
+                "published",
+                publishedSortFieldRef.fieldName
+            )
+
+            val publishedSortValueRef =
+                (publishedSort.component<HasValueReference<PsiElement>>()!!.reference) as Inferred
+            assertEquals(
+                -1,
+                publishedSortValueRef.value
+            )
+
+            val authorSort = sorts.children[3]
+            assertEquals(Name.DESCENDING, authorSort.component<Named>()!!.name)
+
+            val authorSortFieldRef =
+                (authorSort.component<HasFieldReference<PsiElement>>()!!.reference) as FromSchema
+            assertEquals(
+                "author",
+                authorSortFieldRef.fieldName
+            )
+
+            val authorSortValueRef =
+                (authorSort.component<HasValueReference<PsiElement>>()!!.reference) as Inferred
+            assertEquals(
+                -1,
+                authorSortValueRef.value
+            )
+        }
+    }
+}

--- a/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/components/HasSorts.kt
+++ b/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/components/HasSorts.kt
@@ -1,0 +1,8 @@
+package com.mongodb.jbplugin.mql.components
+
+import com.mongodb.jbplugin.mql.HasChildren
+import com.mongodb.jbplugin.mql.Node
+
+data class HasSorts<S>(
+    override val children: List<Node<S>>
+) : HasChildren<S>

--- a/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/components/Named.kt
+++ b/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/components/Named.kt
@@ -52,6 +52,9 @@ enum class Name(val canonical: String) {
     PROJECT("project"),
     INCLUDE("include"),
     EXCLUDE("exclude"),
+    SORT("sort"),
+    ASCENDING("ascending"),
+    DESCENDING("descending"),
     UNKNOWN("<unknown operator>"),
     ;
 


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER-IF-ANY>

  eg. fix(type-hint): infer type of a constant for type checking INTELLIJ-1111
-->

## Description
Includes:
- Parsing of $sort built with Aggregates.sort, limited to, as defined in scope:
  - Sorts.ascending
  - Sorts.descending
  - Sorts.orderBy
- Autocomplete support for fields in Sorts.ascending, Sorts.exclude and Sorts.orderBy
- Linter inspections for field existence and type checks in Sorts

I noticed that we were not parsing incomplete match calls so added that here as well ([eac0239](https://github.com/mongodb/intellij/pull/97/commits/eac0239e56c35a3fff6ed1ec28382c8246ab5ce3))

<!--- Describe your changes in detail so reviewers have enough content on what this PR aims to achieve -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist

- [ ] New tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
- [ ] Changelog is updated accordingly.
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement).

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->