### PR TITLE
feat: add support for parsing Aggregates.addFields stage INTELLIJ-152

### DIFF
--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/JavaDriverCompletionContributorTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/JavaDriverCompletionContributorTest.kt
@@ -740,4 +740,69 @@ public class Repository {
             },
         )
     }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Field;import com.mongodb.client.model.Projections;
+import com.mongodb.client.model.Sorts;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import java.util.List;
+import static com.mongodb.client.model.Filters.*;
+import static com.mongodb.client.model.Updates.*;
+
+public class Repository {
+    private final MongoClient client;
+
+    public Repository(MongoClient client) {
+        this.client = client;
+    }
+
+    public void exampleFind() {
+        client.getDatabase("myDatabase").getCollection("myCollection")
+                .aggregate(List.of(
+                    Aggregates.addFields(
+                        new Field<>("<caret>")
+                    )                
+                ));
+    }
+}
+        """,
+    )
+    fun `should not autocomplete fields from the current namespace in Aggregates#addFields stage`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        fixture.specifyDialect(JavaDriverDialect)
+
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        val namespace = Namespace("myDatabase", "myCollection")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertFalse(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+    }
 }

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/JavaDriverMongoDbAutocompletionPopupHandlerTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/JavaDriverMongoDbAutocompletionPopupHandlerTest.kt
@@ -752,4 +752,70 @@ public class Repository {
             },
         )
     }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Field;import com.mongodb.client.model.Projections;
+import com.mongodb.client.model.Sorts;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import java.util.List;
+import static com.mongodb.client.model.Filters.*;
+import static com.mongodb.client.model.Updates.*;
+
+public class Repository {
+    private final MongoClient client;
+
+    public Repository(MongoClient client) {
+        this.client = client;
+    }
+
+    public void exampleFind() {
+        client.getDatabase("myDatabase").getCollection("myCollection")
+                .aggregate(List.of(
+                    Aggregates.addFields(
+                        new Field<>(<caret>)
+                    )                
+                ));
+    }
+}
+        """,
+    )
+    fun `should not autocomplete fields from the current namespace in Aggregates#addFields stage`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        fixture.specifyDialect(JavaDriverDialect)
+
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        val namespace = Namespace("myDatabase", "myCollection")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        fixture.type('"')
+        val elements = fixture.completeBasic()
+
+        assertFalse(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+    }
 }

--- a/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParser.kt
+++ b/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParser.kt
@@ -892,7 +892,7 @@ fun <T : PsiElement>PsiElement.resolveElementUntil(
 ): T? {
     val expression = meaningfulExpression()
     if (isCorrectResolution(expression)) {
-        return this as T
+        return expression as T
     }
     when (expression) {
         is PsiMethodCallExpression -> {

--- a/packages/mongodb-dialects/java-driver/src/test/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/aggregationparser/AddFieldsParserTest.kt
+++ b/packages/mongodb-dialects/java-driver/src/test/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/aggregationparser/AddFieldsParserTest.kt
@@ -1,0 +1,660 @@
+package com.mongodb.jbplugin.dialects.javadriver.glossary.aggregationparser
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.mongodb.jbplugin.dialects.javadriver.IntegrationTest
+import com.mongodb.jbplugin.dialects.javadriver.ParsingTest
+import com.mongodb.jbplugin.dialects.javadriver.getQueryAtMethod
+import com.mongodb.jbplugin.dialects.javadriver.glossary.JavaDriverDialect
+import com.mongodb.jbplugin.mql.BsonAnyOf
+import com.mongodb.jbplugin.mql.BsonNull
+import com.mongodb.jbplugin.mql.BsonString
+import com.mongodb.jbplugin.mql.components.HasAddedFields
+import com.mongodb.jbplugin.mql.components.HasAggregation
+import com.mongodb.jbplugin.mql.components.HasFieldReference
+import com.mongodb.jbplugin.mql.components.HasValueReference
+import com.mongodb.jbplugin.mql.components.Name
+import com.mongodb.jbplugin.mql.components.Named
+import org.junit.jupiter.api.Assertions.assertEquals
+
+@IntegrationTest
+class AddFieldsParserTest {
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        return this.collection.aggregate(List.of(
+            Aggregates.addFields()
+        ));
+    }
+}
+      """
+    )
+    fun `should be able to parse an empty addFields call`(psiFile: PsiFile) {
+        val aggregate = psiFile.getQueryAtMethod("Aggregation", "getAllBookTitles")
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val addFieldsStageNode = hasAggregation?.children?.get(0)!!
+
+        val named = addFieldsStageNode.component<Named>()!!
+        assertEquals(Name.ADD_FIELDS, named.name)
+
+        assertEquals(0, addFieldsStageNode.component<HasAddedFields<PsiElement>>()!!.children.size)
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Field;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+
+    private String getFieldName3() {
+        return "field3";
+    }
+
+    private String getValueForFieldName3() {
+        return "Value3";
+    }
+    
+    private Field<String> getField3() {
+        return new Field<>(getFieldName3(), getValueForFieldName3());
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String fieldName2 = "field2";
+        String valueForFieldName2 = "Value2";
+        Field<String> field2 = new Field<>(fieldName2, valueForFieldName2);
+        return this.collection.aggregate(List.of(
+            Aggregates.addFields(
+                new Field<>("field1", "Value1"),
+                field2,
+                getField3()
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `should be able to parse addFields call with var args of added fields`(psiFile: PsiFile) {
+        val aggregate = psiFile.getQueryAtMethod("Aggregation", "getAllBookTitles")
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val addFieldsStageNode = hasAggregation?.children?.get(0)!!
+
+        val named = addFieldsStageNode.component<Named>()!!
+        assertEquals(Name.ADD_FIELDS, named.name)
+
+        commonAssertionsOnAddedFieldsComponent(
+            addFieldsStageNode.component<HasAddedFields<PsiElement>>()!!
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Field;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+
+    private String getFieldName3() {
+        return "field3";
+    }
+
+    private String getValueForFieldName3() {
+        return "Value3";
+    }
+    
+    private Field<String> getField3() {
+        return new Field<>(getFieldName3(), getValueForFieldName3());
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String fieldName2 = "field2";
+        String valueForFieldName2 = "Value2";
+        Field<String> field2 = new Field<>(fieldName2, valueForFieldName2);
+        return this.collection.aggregate(List.of(
+            Aggregates.addFields(
+                List.of(
+                    new Field<>("field1", "Value1"),
+                    field2,
+                    getField3()
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `should be able to parse addFields call with List#of of added fields`(psiFile: PsiFile) {
+        val aggregate = psiFile.getQueryAtMethod("Aggregation", "getAllBookTitles")
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val addFieldsStageNode = hasAggregation?.children?.get(0)!!
+
+        val named = addFieldsStageNode.component<Named>()!!
+        assertEquals(Name.ADD_FIELDS, named.name)
+
+        commonAssertionsOnAddedFieldsComponent(
+            addFieldsStageNode.component<HasAddedFields<PsiElement>>()!!
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Field;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+
+    private String getFieldName3() {
+        return "field3";
+    }
+
+    private String getValueForFieldName3() {
+        return "Value3";
+    }
+    
+    private Field<String> getField3() {
+        return new Field<>(getFieldName3(), getValueForFieldName3());
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String fieldName2 = "field2";
+        String valueForFieldName2 = "Value2";
+        Field<String> field2 = new Field<>(fieldName2, valueForFieldName2);
+        List<Field<?>> addedFields = List.of(
+            new Field<>("field1", "Value1"),
+            field2,
+            getField3()
+        );
+        return this.collection.aggregate(List.of(
+            Aggregates.addFields(
+                addedFields
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `should be able to parse addFields call with List#of of added fields, when list is a variable`(
+        psiFile: PsiFile
+    ) {
+        val aggregate = psiFile.getQueryAtMethod("Aggregation", "getAllBookTitles")
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val addFieldsStageNode = hasAggregation?.children?.get(0)!!
+
+        val named = addFieldsStageNode.component<Named>()!!
+        assertEquals(Name.ADD_FIELDS, named.name)
+
+        commonAssertionsOnAddedFieldsComponent(
+            addFieldsStageNode.component<HasAddedFields<PsiElement>>()!!
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Field;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+
+    private String getFieldName3() {
+        return "field3";
+    }
+
+    private String getValueForFieldName3() {
+        return "Value3";
+    }
+    
+    private Field<String> getField3() {
+        return new Field<>(getFieldName3(), getValueForFieldName3());
+    }
+    
+    private List<Field<?>> getAddedFields() {
+        String fieldName2 = "field2";
+        String valueForFieldName2 = "Value2";
+        Field<String> field2 = new Field<>(fieldName2, valueForFieldName2);
+        return List.of(
+            new Field<>("field1", "Value1"),
+            field2,
+            getField3()
+        );
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        return this.collection.aggregate(List.of(
+            Aggregates.addFields(
+                getAddedFields()
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `should be able to parse addFields call with List#of of added fields, when list is retrieved from method call`(
+        psiFile: PsiFile
+    ) {
+        val aggregate = psiFile.getQueryAtMethod("Aggregation", "getAllBookTitles")
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val addFieldsStageNode = hasAggregation?.children?.get(0)!!
+
+        val named = addFieldsStageNode.component<Named>()!!
+        assertEquals(Name.ADD_FIELDS, named.name)
+
+        commonAssertionsOnAddedFieldsComponent(
+            addFieldsStageNode.component<HasAddedFields<PsiElement>>()!!
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Field;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+
+    private String getFieldName3() {
+        return "field3";
+    }
+
+    private String getValueForFieldName3() {
+        return "Value3";
+    }
+    
+    private Field<String> getField3() {
+        return new Field<>(getFieldName3(), getValueForFieldName3());
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String fieldName2 = "field2";
+        String valueForFieldName2 = "Value2";
+        Field<String> field2 = new Field<>(fieldName2, valueForFieldName2);
+        return this.collection.aggregate(List.of(
+            Aggregates.addFields(
+                Arrays.asList(
+                    new Field<>("field1", "Value1"),
+                    field2,
+                    getField3()
+                )
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `should be able to parse addFields call with Arrays#asList of added fields`(
+        psiFile: PsiFile
+    ) {
+        val aggregate = psiFile.getQueryAtMethod("Aggregation", "getAllBookTitles")
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val addFieldsStageNode = hasAggregation?.children?.get(0)!!
+
+        val named = addFieldsStageNode.component<Named>()!!
+        assertEquals(Name.ADD_FIELDS, named.name)
+
+        commonAssertionsOnAddedFieldsComponent(
+            addFieldsStageNode.component<HasAddedFields<PsiElement>>()!!
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Field;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+
+    private String getFieldName3() {
+        return "field3";
+    }
+
+    private String getValueForFieldName3() {
+        return "Value3";
+    }
+    
+    private Field<String> getField3() {
+        return new Field<>(getFieldName3(), getValueForFieldName3());
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String fieldName2 = "field2";
+        String valueForFieldName2 = "Value2";
+        Field<String> field2 = new Field<>(fieldName2, valueForFieldName2);
+        List<Field<?>> addedFields = Arrays.asList(
+            new Field<>("field1", "Value1"),
+            field2,
+            getField3()
+        );
+        return this.collection.aggregate(List.of(
+            Aggregates.addFields(
+                addedFields
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `should be able to parse addFields call with Arrays#asList of added fields, when list is a variable`(
+        psiFile: PsiFile
+    ) {
+        val aggregate = psiFile.getQueryAtMethod("Aggregation", "getAllBookTitles")
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val addFieldsStageNode = hasAggregation?.children?.get(0)!!
+
+        val named = addFieldsStageNode.component<Named>()!!
+        assertEquals(Name.ADD_FIELDS, named.name)
+
+        commonAssertionsOnAddedFieldsComponent(
+            addFieldsStageNode.component<HasAddedFields<PsiElement>>()!!
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Field;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+
+    private String getFieldName3() {
+        return "field3";
+    }
+
+    private String getValueForFieldName3() {
+        return "Value3";
+    }
+    
+    private Field<String> getField3() {
+        return new Field<>(getFieldName3(), getValueForFieldName3());
+    }
+    
+    private List<Field<?>> getAddedFields() {
+        String fieldName2 = "field2";
+        String valueForFieldName2 = "Value2";
+        Field<String> field2 = new Field<>(fieldName2, valueForFieldName2);
+        return Arrays.asList(
+            new Field<>("field1", "Value1"),
+            field2,
+            getField3()
+        );
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        return this.collection.aggregate(List.of(
+            Aggregates.addFields(
+                getAddedFields()
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `should be able to parse addFields call with Arrays#asList of added fields, when list is retrieved from method call`(
+        psiFile: PsiFile
+    ) {
+        val aggregate = psiFile.getQueryAtMethod("Aggregation", "getAllBookTitles")
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val addFieldsStageNode = hasAggregation?.children?.get(0)!!
+
+        val named = addFieldsStageNode.component<Named>()!!
+        assertEquals(Name.ADD_FIELDS, named.name)
+
+        commonAssertionsOnAddedFieldsComponent(
+            addFieldsStageNode.component<HasAddedFields<PsiElement>>()!!
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Aggregation.java",
+        value = """
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Field;
+import com.mongodb.client.model.Filters;import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.*;
+
+public final class Aggregation {
+    private final MongoCollection<Document> collection;
+
+    public Aggregation(MongoClient client) {
+        this.collection = client.getDatabase("simple").getCollection("books");
+    }
+
+    private String getFieldName3() {
+        return "field3";
+    }
+
+    private String getValueForFieldName3() {
+        return "Value3";
+    }
+    
+    private Field<String> getField3() {
+        return new Field<>(getFieldName3(), getValueForFieldName3());
+    }
+
+    public AggregateIterable<Document> getAllBookTitles(ObjectId id) {
+        String fieldName2 = "field2";
+        String valueForFieldName2 = "Value2";
+        Field<String> field2 = new Field<>(fieldName2, Filters.eq("asd"));
+        return this.collection.aggregate(List.of(
+            Aggregates.addFields(
+                new Field<>("field1", "Value1"),
+                field2,
+                getField3()
+            )
+        ));
+    }
+}
+      """
+    )
+    fun `should skip parsing fields where value is an expression`(psiFile: PsiFile) {
+        val aggregate = psiFile.getQueryAtMethod("Aggregation", "getAllBookTitles")
+        val parsedAggregate = JavaDriverDialect.parser.parse(aggregate)
+        val hasAggregation = parsedAggregate.component<HasAggregation<PsiElement>>()
+        assertEquals(1, hasAggregation?.children?.size)
+
+        val addFieldsStageNode = hasAggregation?.children?.get(0)!!
+
+        val named = addFieldsStageNode.component<Named>()!!
+        assertEquals(Name.ADD_FIELDS, named.name)
+
+        val addedFields = addFieldsStageNode.component<HasAddedFields<PsiElement>>()!!
+        assertEquals(2, addedFields.children.size)
+
+        val field1Node = addedFields.children[0]
+        val field1FieldReference = (field1Node.component<HasFieldReference<PsiElement>>()!!.reference as HasFieldReference.Computed)
+        assertEquals("field1", field1FieldReference.fieldName)
+        val field1ValueReference = (field1Node.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant)
+        assertEquals("Value1", field1ValueReference.value)
+        assertEquals(BsonAnyOf(BsonString, BsonNull), field1ValueReference.type)
+
+        val field2Node = addedFields.children[1]
+        val field2FieldReference = (field2Node.component<HasFieldReference<PsiElement>>()!!.reference as HasFieldReference.Computed)
+        assertEquals("field3", field2FieldReference.fieldName)
+        val field2ValueReference = (field2Node.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant)
+        assertEquals("Value3", field2ValueReference.value)
+        assertEquals(BsonAnyOf(BsonString, BsonNull), field2ValueReference.type)
+    }
+
+    companion object {
+        fun commonAssertionsOnAddedFieldsComponent(addedFields: HasAddedFields<PsiElement>) {
+            assertEquals(3, addedFields.children.size)
+
+            val field1Node = addedFields.children[0]
+            val field1FieldReference = (field1Node.component<HasFieldReference<PsiElement>>()!!.reference as HasFieldReference.Computed)
+            assertEquals("field1", field1FieldReference.fieldName)
+            val field1ValueReference = (field1Node.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant)
+            assertEquals("Value1", field1ValueReference.value)
+            assertEquals(BsonAnyOf(BsonString, BsonNull), field1ValueReference.type)
+
+            val field2Node = addedFields.children[1]
+            val field2FieldReference = (field2Node.component<HasFieldReference<PsiElement>>()!!.reference as HasFieldReference.Computed)
+            assertEquals("field2", field2FieldReference.fieldName)
+            val field2ValueReference = (field2Node.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant)
+            assertEquals("Value2", field2ValueReference.value)
+            assertEquals(BsonAnyOf(BsonString, BsonNull), field2ValueReference.type)
+
+            val field3Node = addedFields.children[2]
+            val field3FieldReference = (field3Node.component<HasFieldReference<PsiElement>>()!!.reference as HasFieldReference.Computed)
+            assertEquals("field3", field3FieldReference.fieldName)
+            val field3ValueReference = (field3Node.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant)
+            assertEquals("Value3", field3ValueReference.value)
+            assertEquals(BsonAnyOf(BsonString, BsonNull), field3ValueReference.type)
+        }
+    }
+}

--- a/packages/mongodb-dialects/mongosh/src/main/kotlin/com/mongodb/jbplugin/dialects/mongosh/MongoshDialectFormatter.kt
+++ b/packages/mongodb-dialects/mongosh/src/main/kotlin/com/mongodb/jbplugin/dialects/mongosh/MongoshDialectFormatter.kt
@@ -5,6 +5,7 @@ import com.mongodb.jbplugin.dialects.OutputQuery
 import com.mongodb.jbplugin.dialects.mongosh.backend.MongoshBackend
 import com.mongodb.jbplugin.mql.*
 import com.mongodb.jbplugin.mql.components.*
+import com.mongodb.jbplugin.mql.components.HasFieldReference.Computed
 import com.mongodb.jbplugin.mql.components.HasFieldReference.FromSchema
 import com.mongodb.jbplugin.mql.components.HasFieldReference.Unknown
 import com.mongodb.jbplugin.mql.parser.anyError
@@ -340,6 +341,7 @@ private fun <S> MongoshBackend.resolveValueReference(
 
 private fun <S> MongoshBackend.resolveFieldReference(fieldRef: HasFieldReference<S>) =
     when (val ref = fieldRef.reference) {
+        is Computed -> registerConstant(ref.fieldName)
         is FromSchema -> registerConstant(ref.fieldName)
         is Unknown -> registerVariable("field", BsonAny)
     }

--- a/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/components/HasAddedFields.kt
+++ b/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/components/HasAddedFields.kt
@@ -1,0 +1,8 @@
+package com.mongodb.jbplugin.mql.components
+
+import com.mongodb.jbplugin.mql.HasChildren
+import com.mongodb.jbplugin.mql.Node
+
+data class HasAddedFields<S>(
+    override val children: List<Node<S>>
+) : HasChildren<S>

--- a/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/components/HasFieldReference.kt
+++ b/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/components/HasFieldReference.kt
@@ -23,4 +23,13 @@ data class HasFieldReference<S>(
         val fieldName: String,
         val displayName: String = fieldName,
     ) : FieldReference<S>
+
+    /**
+     * Encodes a FieldReference that does not exist in the original schema and the value of which
+     * is computed using some expression.
+     */
+    data class Computed<S>(
+        val source: S,
+        val fieldName: String,
+    ) : FieldReference<S>
 }

--- a/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/components/Named.kt
+++ b/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/components/Named.kt
@@ -55,6 +55,7 @@ enum class Name(val canonical: String) {
     SORT("sort"),
     ASCENDING("ascending"),
     DESCENDING("descending"),
+    ADD_FIELDS("addFields"),
     UNKNOWN("<unknown operator>"),
     ;
 


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER-IF-ANY>

  eg. fix(type-hint): infer type of a constant for type checking INTELLIJ-1111
-->

## Description
Includes:
- Parsing of $addFields built with Aggregates.addFields, limited to, as defined in scope:
  - new Field expression where the value is constant
- Autocomplete disabled when the cursor is inside addFields since at some point we would like to show warnings about possible replacement of existing fields.
- Tests for no linter warnings triggered for addFields stage

<!--- Describe your changes in detail so reviewers have enough content on what this PR aims to achieve -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist

- [ ] New tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
- [ ] Changelog is updated accordingly.
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement).

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->