### PR TITLE
chore(ci): cleanup gha workflows

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -204,3 +204,5 @@ ij_yaml_keep_line_breaks = true
 ij_yaml_space_before_colon = false
 ij_yaml_spaces_within_braces = true
 ij_yaml_spaces_within_brackets = true
+tab_width = 2
+indent_size = 2

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       versionBump:
-        description: 'Version bump'
+        description: "Version bump"
         type: choice
         required: true
-        default: 'patch'
+        default: "patch"
         options:
           - patch
           - minor
@@ -26,16 +26,24 @@ jobs:
     name: "Prepare Release"
     runs-on: ubuntu-latest
     steps:
+      - uses: mongodb-js/devtools-shared/actions/setup-bot-token@main
+        id: app-token
+        with:
+          app-id: ${{ vars.DEVTOOLS_BOT_APP_ID }}
+          private-key: ${{ secrets.DEVTOOLS_BOT_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '17'
-          cache: 'gradle'
+          distribution: "temurin"
+          java-version: "17"
+          cache: "gradle"
+
       - name: Determine Next Version
         shell: bash
         env:
@@ -97,28 +105,24 @@ jobs:
       - name: Create Draft Release
         shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.SVC_DEVTOOLSBOT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -e
           echo Creating draft release for: "${RELEASE_TAG}"
 
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          
           git add .
           git commit --no-verify -m "Release ${RELEASE_TAG}"
           git tag ${RELEASE_TAG}
           git push origin ${RELEASE_TAG}
-          
+
           GIT_REF=$(git rev-parse ${RELEASE_TAG})
           ls packages/jetbrains-plugin/build/distributions/jetbrains-plugin.zip
-          
+
           CHANGELOG=$(./gradlew --quiet --console=plain :packages:jetbrains-plugin:getChangelog)
-          
+
           gh release create "${RELEASE_TAG}" \
             --title "${RELEASE_TAG}" \
             --notes "${CHANGELOG}" \
             --target "${GIT_REF}" \
             --draft \
             packages/jetbrains-plugin/build/distributions/jetbrains-plugin.zip
-         

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -2,34 +2,43 @@ name: Publish Release
 
 on:
   release:
-    types: [ published ]
+    types: [published]
 
 jobs:
   prepare-release:
     name: "Prepare Release"
     runs-on: ubuntu-latest
     steps:
+      - uses: mongodb-js/devtools-shared/actions/setup-bot-token@main
+        id: app-token
+        with:
+          app-id: ${{ vars.DEVTOOLS_BOT_APP_ID }}
+          private-key: ${{ secrets.DEVTOOLS_BOT_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '17'
-          cache: 'gradle'
+          distribution: "temurin"
+          java-version: "17"
+          cache: "gradle"
 
-      - uses: robinraju/release-downloader@v1.10
+      - uses: robinraju/release-downloader@a96f54c1b5f5e09e47d9504526e96febd949d4c2 # 1.11
         with:
           tag: ${{ github.ref_name }}
-          fileName: 'jetbrains-plugin.zip'
-          out-file-path: 'packages/jetbrains-plugin/build/distributions/'
+          fileName: "jetbrains-plugin.zip"
+          out-file-path: "packages/jetbrains-plugin/build/distributions/"
+
       - name: Publish Plugin In General Availability
         shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.SVC_DEVTOOLSBOT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           JB_PUBLISH_CHANNEL: "ga"
           JB_PUBLISH_TOKEN: ${{ secrets.JB_PUBLISH_TOKEN }}
           JB_CERTIFICATE_CHAIN: ${{ secrets.JB_CERTIFICATE_CHAIN }}
@@ -37,10 +46,9 @@ jobs:
           JB_PRIVATE_KEY_PASSWORD: ${{ secrets.JB_PRIVATE_KEY_PASSWORD }}
         run: |
           set -e
-          
+
           ./gradlew ":packages:jetbrains-plugin:publishPlugin" $(./gradlew ":packages:jetbrains-plugin:publishPlugin" --dry-run | awk '/^:/ { print "-x" $1 }' | sed '$ d')
-          
+
           git checkout main
           git merge ${{ github.ref_name }}
           git push origin main
-          

--- a/.github/workflows/quality-check.yaml
+++ b/.github/workflows/quality-check.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   changelog-check:
-    name: 'Changelog Check'
+    name: "Changelog Check"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -23,7 +23,7 @@ jobs:
         if: |
           startsWith(github.event.pull_request.title, 'fix:') ||
           startsWith(github.event.pull_request.title, 'fix(')
-        uses: actions-ecosystem/action-remove-labels@v1
+        uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # 1.3.0
         with:
           labels: feat
 
@@ -31,7 +31,7 @@ jobs:
         if: |
           startsWith(github.event.pull_request.title, 'feat:') ||
           startsWith(github.event.pull_request.title, 'feat(')
-        uses: actions-ecosystem/action-remove-labels@v1
+        uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # 1.3.0
         with:
           labels: fix
 
@@ -39,111 +39,129 @@ jobs:
         if: |
           startsWith(github.event.pull_request.title, 'fix:') ||
           startsWith(github.event.pull_request.title, 'fix(')
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions-ecosystem/action-add-labels@bd52874380e3909a1ac983768df6976535ece7f8 # 1.1.0
         with:
           labels: fix
+          github_token: ${{ github.token }}
 
       - name: add label based on title - feat
         if: |
           startsWith(github.event.pull_request.title, 'feat:') ||
           startsWith(github.event.pull_request.title, 'feat(')
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions-ecosystem/action-add-labels@bd52874380e3909a1ac983768df6976535ece7f8 # 1.1.0
         with:
           labels: feature
+          github_token: ${{ github.token }}
 
       - name: add label based on title - chore
         if: |
           startsWith(github.event.pull_request.title, 'chore:') ||
           startsWith(github.event.pull_request.title, 'chore(')
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions-ecosystem/action-add-labels@bd52874380e3909a1ac983768df6976535ece7f8 # 1.1.0
         with:
           labels: no release notes
+          github_token: ${{ github.token }}
+
       - name: Verify Changed files
-        uses: tj-actions/verify-changed-files@v20
+        uses: tj-actions/verify-changed-files@6ed7632824d235029086612d4330d659005af687 # 20.0.1
         id: verify-changelog-files
         with:
           files: |
             CHANGELOG.md
-      - uses: mheap/github-action-required-labels@v1
-        if: steps.verify-changed-files.outputs.files_changed == 'false'
+
+      - uses: mheap/github-action-required-labels@5847eef68201219cf0a4643ea7be61e77837bbce # 5.4.1
+        if: ${{ steps.verify-changelog-files.outputs.files_changed == 'false' }}
         with:
           mode: minimum
           count: 1
           labels: "no release notes"
 
   catalog-check:
-    name: 'Catalog Updates Check'
+    name: "Catalog Updates Check"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: "temurin"
+          java-version: "17"
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-            dependency-graph: 'generate-and-submit'
-            dependency-graph-continue-on-failure: false
-            gradle-home-cache-cleanup: true
+          dependency-graph: "generate-and-submit"
+          dependency-graph-continue-on-failure: false
+          gradle-home-cache-cleanup: true
+
       - name: Run Dependency Updates
         run: |
           ./gradlew --quiet --console=plain dependencyUpdates
 
   style-check:
-    name: 'Style Check'
+    name: "Style Check"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: "temurin"
+          java-version: "17"
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-            gradle-home-cache-cleanup: true
+          gradle-home-cache-cleanup: true
+
       - name: Run Linter
         run: |
           ./gradlew --quiet --console=plain ktlintCheck
+
       - name: Push Checkstyle report
-        uses: jwgmeligmeyling/checkstyle-github-action@v1.2
+        uses: jwgmeligmeyling/checkstyle-github-action@50292990e18466f2c5d95d04ff5fab931254fa5f # 1.2.0
         if: success() || failure() # always run even if the previous step fails
         with:
-          path: '**/*Check.xml'
+          path: "**/*Check.xml"
 
   unit-tests:
-    name: 'Unit and Integration Tests'
+    name: "Unit and Integration Tests"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: "temurin"
+          java-version: "17"
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-            gradle-home-cache-cleanup: true
+          gradle-home-cache-cleanup: true
+
       - name: Setup Docker (for Test Containers)
         run: |
           sudo apt update -y
           sudo apt install -y docker docker-compose
+
       - name: Run Test Suite
         run: |
-            ./gradlew --stacktrace --console=plain check
+          ./gradlew --stacktrace --console=plain check
+
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@a427a90771729d8f85b6ab0cdaa1a5929cab985d # 5.0.0
         if: success() || failure() # always run even if the previous step fails
         with:
-            report_paths: '**/build/test-results/test/TEST-*.xml'
-      - uses: madrapps/jacoco-report@v1.6.1
+          report_paths: "**/build/test-results/test/TEST-*.xml"
+
+      - uses: madrapps/jacoco-report@7c362aca34caf958e7b1c03464bd8781db9f8da7 # 1.7.1
         if: success() || failure() # always run even if the previous step fails
         with:
           paths: "**/testCodeCoverageReport.xml"
@@ -157,7 +175,7 @@ jobs:
           fail-emoji: "🚫"
 
   functional-tests:
-    name: 'UI Tests'
+    name: "UI Tests"
     runs-on: ubuntu-latest
     needs:
       - catalog-check
@@ -166,28 +184,33 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: "temurin"
+          java-version: "17"
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-            gradle-home-cache-cleanup: true
+          gradle-home-cache-cleanup: true
+
       - name: Restore IDEA Cached Indexes
         uses: actions/cache/restore@v4
         with:
-          key: 'intellij-indexes-cache'
+          key: "intellij-indexes-cache"
           path: |
             packages/jetbrains-plugin/build/idea-sandbox/system-test/index
             packages/jetbrains-plugin/build/idea-sandbox/system/index
+
       - name: Prepare License Key
         env:
           JB_TEST_KEY: ${{ secrets.JB_TEST_KEY }}
         run: |
           mkdir -p packages/jetbrains-plugin/build/idea-sandbox/config-uiTest
           echo "$JB_TEST_KEY" | base64 -d > packages/jetbrains-plugin/build/idea-sandbox/config-uiTest/idea.key
+
       - name: Start UI Test Environment
         run: |
           export DISPLAY=:99.0
@@ -195,16 +218,19 @@ jobs:
           sleep 10
           mkdir -p packages/jetbrains-plugin/build/reports
           ./gradlew :packages:jetbrains-plugin:runIdeForUiTests > packages/jetbrains-plugin/build/reports/idea.log &
+
       - name: Wait for IDE to start
-        uses: jtalk/url-health-check-action@v3
+        uses: jtalk/url-health-check-action@b716ccb6645355dd9fcce8002ce460e5474f7f00 # v4
         with:
           url: "http://127.0.0.1:8082"
           max-attempts: 15
           retry-delay: 30s
+
       - name: Run UI Tests
         run: |
           export DISPLAY=:99.0
           ./gradlew --quiet --console=plain :packages:jetbrains-plugin:uiTest
+
       - uses: actions/upload-artifact@v4
         name: Upload UI Test Failures
         if: success() || failure() # always run even if the previous step fails
@@ -217,19 +243,21 @@ jobs:
             **/build/idea-sandbox/system/**/*.log
             **/build/idea-sandbox/system-test/**/*.log
             **/video/**/*.avi
+
       - name: Cache IDEA Indexes
         uses: actions/cache/save@v4
         if: success() || failure() # always run even if the previous step fails
         with:
-          key: 'intellij-indexes-cache'
+          key: "intellij-indexes-cache"
           path: |
-              packages/jetbrains-plugin/build/idea-sandbox/system-test/index
-              packages/jetbrains-plugin/build/idea-sandbox/system/index
+            packages/jetbrains-plugin/build/idea-sandbox/system-test/index
+            packages/jetbrains-plugin/build/idea-sandbox/system/index
+
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@a427a90771729d8f85b6ab0cdaa1a5929cab985d # 5.0.0
         if: success() || failure() # always run even if the previous step fails
         with:
-          report_paths: '**/build/test-results/test/TEST-*.xml'
+          report_paths: "**/build/test-results/test/TEST-*.xml"
 
   fitness-check:
     name: "Fitness Check"
@@ -239,20 +267,24 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: "temurin"
+          java-version: "17"
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-            gradle-home-cache-cleanup: true
+          gradle-home-cache-cleanup: true
+
       - name: Performance Tests
         run: |
           ./gradlew --quiet --console=plain ":packages:jetbrains-plugin:jmh"
+
       - name: JMH Benchmark Action
-        uses: kitlangton/jmh-benchmark-action@main
+        uses: kitlangton/jmh-benchmark-action@e7255850c5248fe630d7b5ca4ec4f3671765a9c7 # 0.1.1
         with:
           jmh-output-path: build/reports/jmh/results.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -269,15 +301,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: "temurin"
+          java-version: "17"
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-            gradle-home-cache-cleanup: true
+          gradle-home-cache-cleanup: true
+
       - name: Verify Plugin
         run: |
           ./gradlew ":packages:jetbrains-plugin:verifyPlugin"


### PR DESCRIPTION
## Description

This is a general cleanup/sanitation of gha workflows. It bumps some 3rd party workflows to latest and ensures we only reference them using commit shas (per [github's recommendations](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)). Additionally, it moves our usage of the devtoolsbot user to the github app.
