### PR TITLE
chore(ci): fix the changelog check

### DIFF
--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: bcoe/conventional-release-labels@886f696738527c7be444262c327c89436dfb95a8 # 1.3.1
         with:
           type_labels: '{"feat": "feat", "fix": "fix", "breaking": "breaking", "chore": "no release notes" }'
-          ignored_types: ""
+          ignored_types: "[]"
       - name: Check Changelog
         uses: dangoslen/changelog-enforcer@204e7d3ef26579f4cd0fd759c57032656fdf23c7 # 3.6.1
         with:

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -1,0 +1,22 @@
+name: "Check Changelog"
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+      - uses: bcoe/conventional-release-labels@886f696738527c7be444262c327c89436dfb95a8 # 1.3.1
+        with:
+          type_labels: '{"feat": "feat", "fix": "fix", "breaking": "breaking", "chore": "no release notes" }'
+          ignored_types: ""
+      - name: Check Changelog
+        uses: dangoslen/changelog-enforcer@204e7d3ef26579f4cd0fd759c57032656fdf23c7 # 3.6.1
+        with:
+          skipLabels: no release notes
+          missingUpdateErrorMessage: Please add an entry in CHANGELOG.md or apply the 'no release notes' label to skip this check.

--- a/.github/workflows/quality-check.yaml
+++ b/.github/workflows/quality-check.yaml
@@ -16,6 +16,7 @@ jobs:
   changelog-check:
     name: "Changelog Check"
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/quality-check.yaml
+++ b/.github/workflows/quality-check.yaml
@@ -13,62 +13,6 @@ permissions:
   checks: write
 
 jobs:
-  changelog-check:
-    name: "Changelog Check"
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: remove label not matching title - fix
-        if: |
-          startsWith(github.event.pull_request.title, 'fix:') ||
-          startsWith(github.event.pull_request.title, 'fix(')
-        uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # 1.3.0
-        with:
-          labels: feat
-
-      - name: remove label not matching title - feat
-        if: |
-          startsWith(github.event.pull_request.title, 'feat:') ||
-          startsWith(github.event.pull_request.title, 'feat(')
-        uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # 1.3.0
-        with:
-          labels: fix
-
-      - name: add label based on title - fix
-        if: |
-          startsWith(github.event.pull_request.title, 'fix:') ||
-          startsWith(github.event.pull_request.title, 'fix(')
-        uses: actions-ecosystem/action-add-labels@bd52874380e3909a1ac983768df6976535ece7f8 # 1.1.0
-        with:
-          labels: fix
-          github_token: ${{ github.token }}
-
-      - name: add label based on title - feat
-        if: |
-          startsWith(github.event.pull_request.title, 'feat:') ||
-          startsWith(github.event.pull_request.title, 'feat(')
-        uses: actions-ecosystem/action-add-labels@bd52874380e3909a1ac983768df6976535ece7f8 # 1.1.0
-        with:
-          labels: feature
-          github_token: ${{ github.token }}
-
-      - name: add label based on title - chore
-        if: |
-          startsWith(github.event.pull_request.title, 'chore:') ||
-          startsWith(github.event.pull_request.title, 'chore(')
-        uses: actions-ecosystem/action-add-labels@bd52874380e3909a1ac983768df6976535ece7f8 # 1.1.0
-        with:
-          labels: no release notes
-          github_token: ${{ github.token }}
-
-      - name: Check Changelog
-        uses: dangoslen/changelog-enforcer@204e7d3ef26579f4cd0fd759c57032656fdf23c7 # 3.6.1
-        with:
-          skipLabels: no release notes
-          missingUpdateErrorMessage: Please add an entry in CHANGELOG.md or apply the 'no-changelog' label to skip this check.
-
   catalog-check:
     name: "Catalog Updates Check"
     runs-on: ubuntu-latest

--- a/.github/workflows/quality-check.yaml
+++ b/.github/workflows/quality-check.yaml
@@ -62,19 +62,11 @@ jobs:
           labels: no release notes
           github_token: ${{ github.token }}
 
-      - name: Verify Changed files
-        uses: tj-actions/verify-changed-files@6ed7632824d235029086612d4330d659005af687 # 20.0.1
-        id: verify-changelog-files
+      - name: Check Changelog
+        uses: dangoslen/changelog-enforcer@204e7d3ef26579f4cd0fd759c57032656fdf23c7 # 3.6.1
         with:
-          files: |
-            CHANGELOG.md
-
-      - uses: mheap/github-action-required-labels@5847eef68201219cf0a4643ea7be61e77837bbce # 5.4.1
-        if: steps.verify-changed-files.outputs.files_changed == 'false'
-        with:
-          mode: minimum
-          count: 1
-          labels: "no release notes"
+          skipLabels: no release notes
+          missingUpdateErrorMessage: Please add an entry in CHANGELOG.md or apply the 'no-changelog' label to skip this check.
 
   catalog-check:
     name: "Catalog Updates Check"


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER-IF-ANY>

  eg. fix(type-hint): infer type of a constant for type checking INTELLIJ-1111
-->

## Description

The previous check was incorrect - it was never actually running because the step name was invalid. I've moved it to a dedicated workflow because we need different triggers for the check to work correctly (e.g. it wouldn't pick up manually adding a label, because that would not trigger the workflow). I've also simplified some of the logic as we were using quite a few steps before which could be combined into a single one.

### Checklist

- [ ] New tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
- [ ] Changelog is updated accordingly.
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement).

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->