### PR TITLE
fix: Filters.(and/or/nor) not working with iterable arguments for Java Driver dialect INTELLIJ-157

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,5 +57,6 @@ This data source is used for autocompletion and type checking.
 ### Removed
 
 ### Fixed
+* [INTELLIJ-157](https://jira.mongodb.org/browse/INTELLIJ-157): Unable to parse and hence inspect `Filters.and`, `Filters.or` and `Filters.nor`, in code that uses Java Driver, when argument for these method calls is a parseable Java Iterable. 
 
 ### Security

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/impl/JavaDriverFieldCheckLinterInspectionTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/impl/JavaDriverFieldCheckLinterInspectionTest.kt
@@ -148,6 +148,7 @@ import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import org.bson.Document;
+import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
 import static com.mongodb.client.model.Filters.*;
 
@@ -158,7 +159,8 @@ public class Repository {
         this.client = client;
     }
 
-    public FindIterable<Document> exampleFind() {
+    // and queries
+    public FindIterable<Document> inlineAndQuery() {
         return client.getDatabase("myDatabase")
                 .getCollection("myCollection")
                 .find(
@@ -167,10 +169,102 @@ public class Repository {
                     )
                 );
     }
+    
+    public FindIterable<Document> andQueryFromAVariableWithVariableFieldName() {
+        var fieldName = "nonExistingField";
+        var andQuery = and(
+            eq(<warning descr="Field \"nonExistingField\" does not exist in collection \"myDatabase.myCollection\"">fieldName</warning>, "123")
+        );
+        return client.getDatabase("myDatabase")
+                .getCollection("myCollection")
+                .find(andQuery);
+    }
+    
+    public FindIterable<Document> andQueryFromAMethodCallWithFieldNameFromMethodCall() {
+        return client.getDatabase("myDatabase")
+                .getCollection("myCollection")
+                .find(getAndQueryWithFieldNameFromMethodCall());
+    }
+    
+    private Bson getAndQueryWithFieldNameFromMethodCall() {
+        return and(
+            eq(<warning descr="Field \"nonExistingField\" does not exist in collection \"myDatabase.myCollection\"">getFieldName()</warning>, "123")
+        );
+    }
+    
+    private String getFieldName() {
+        return "nonExistingField";
+    }
+    
+    // or queries
+    public FindIterable<Document> inlineOrQuery() {
+        return client.getDatabase("myDatabase")
+                .getCollection("myCollection")
+                .find(
+                    or(
+                        eq(<warning descr="Field \"nonExistingField\" does not exist in collection \"myDatabase.myCollection\"">"nonExistingField"</warning>, "123")
+                    )
+                );
+    }
+    
+    public FindIterable<Document> orQueryFromAVariableWithVariableFieldName() {
+        var fieldName = "nonExistingField";
+        var orQuery = or(
+            eq(<warning descr="Field \"nonExistingField\" does not exist in collection \"myDatabase.myCollection\"">fieldName</warning>, "123")
+        );
+        return client.getDatabase("myDatabase")
+                .getCollection("myCollection")
+                .find(orQuery);
+    }
+    
+    public FindIterable<Document> orQueryFromAMethodCallWithFieldNameFromMethodCall() {
+        return client.getDatabase("myDatabase")
+                .getCollection("myCollection")
+                .find(getOrQueryWithFieldNameFromMethodCall());
+    }
+    
+    private Bson getOrQueryWithFieldNameFromMethodCall() {
+        return or(
+            eq(<warning descr="Field \"nonExistingField\" does not exist in collection \"myDatabase.myCollection\"">getFieldName()</warning>, "123")
+        );
+    }
+    
+    // nor queries
+    public FindIterable<Document> inlineNorQuery() {
+        return client.getDatabase("myDatabase")
+                .getCollection("myCollection")
+                .find(
+                    nor(
+                        eq(<warning descr="Field \"nonExistingField\" does not exist in collection \"myDatabase.myCollection\"">"nonExistingField"</warning>, "123")
+                    )
+                );
+    }
+    
+    public FindIterable<Document> norQueryFromAVariableWithVariableFieldName() {
+        var fieldName = "nonExistingField";
+        var norQuery = nor(
+            eq(<warning descr="Field \"nonExistingField\" does not exist in collection \"myDatabase.myCollection\"">fieldName</warning>, "123")
+        );
+        return client.getDatabase("myDatabase")
+                .getCollection("myCollection")
+                .find(norQuery);
+    }
+    
+    public FindIterable<Document> norQueryFromAMethodCallWithFieldNameFromMethodCall() {
+        return client.getDatabase("myDatabase")
+                .getCollection("myCollection")
+                .find(getNorQueryWithFieldNameFromMethodCall());
+    }
+    
+    private Bson getNorQueryWithFieldNameFromMethodCall() {
+        return nor(
+            eq(<warning descr="Field \"nonExistingField\" does not exist in collection \"myDatabase.myCollection\"">getFieldName()</warning>, "123")
+        );
+    }
 }
         """,
     )
-    fun `shows an inspection when a field, referenced in a nested $and query, does not exists in the current namespace`(
+    fun `shows an inspection when a field, referenced in different forms of a nested $and, $or and $nor query, does not exists in the current namespace`(
         fixture: CodeInsightTestFixture,
     ) {
         val (dataSource, readModelProvider) = fixture.setupConnection()

--- a/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParser.kt
+++ b/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParser.kt
@@ -289,8 +289,19 @@ object JavaDriverDialectParser : DialectParser<PsiElement> {
                     HasValueReference(valueReference)
                 ),
             )
-        } else if (method.isVarArgs || method.name == "not") {
-            // Filters.and, Filters.or... are varargs
+        } else if (method.name == "and" || method.name == "or" || method.name == "nor") {
+            return Node(
+                filter,
+                listOf(
+                    Named(Name.from(method.name)),
+                    HasFilter(
+                        filter.getVarArgsOrIterableArgs()
+                            .mapNotNull { resolveBsonBuilderCall(it, FILTERS_FQN) }
+                            .mapNotNull { parseFilterExpression(it) },
+                    ),
+                ),
+            )
+        } else if (method.name == "not") {
             return Node(
                 filter,
                 listOf(

--- a/packages/mongodb-dialects/java-driver/src/test/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParserTest.kt
+++ b/packages/mongodb-dialects/java-driver/src/test/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParserTest.kt
@@ -586,7 +586,7 @@ public class Repository {
 }
         """,
     )
-    fun `supports vararg operators`(psiFile: PsiFile) {
+    fun `supports filters built with Filters#and using varargs arguments`(psiFile: PsiFile) {
         val query = psiFile.getQueryAtMethod("Repository", "findReleasedBooks")
         val parsedQuery = JavaDriverDialect.parser.parse(query)
 
@@ -652,7 +652,9 @@ public class Repository {
 }
         """,
     )
-    fun `supports vararg operators with parameterised queries in variables`(psiFile: PsiFile) {
+    fun `supports filters built with Filters#and using varargs arguments passed as a variable`(
+        psiFile: PsiFile
+    ) {
         val query = psiFile.getQueryAtMethod("Repository", "findReleasedBooks")
         val parsedQuery = JavaDriverDialect.parser.parse(query)
 
@@ -661,6 +663,484 @@ public class Repository {
 
         val and = hasChildren.children[0]
         assertEquals(Name.AND, and.component<Named>()!!.name)
+        val andChildren = and.component<HasFilter<Unit?>>()!!
+
+        val firstEq = andChildren.children[0]
+        assertEquals(
+            "released",
+            (firstEq.component<HasFieldReference<Unit?>>()!!.reference as HasFieldReference.FromSchema).fieldName,
+        )
+        assertEquals(
+            BsonAnyOf(BsonNull, BsonBoolean),
+            (firstEq.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant).type,
+        )
+        assertEquals(
+            true,
+            (firstEq.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant).value
+        )
+
+        val secondEq = andChildren.children[1]
+        assertEquals(
+            "hidden",
+            (secondEq.component<HasFieldReference<Unit?>>()!!.reference as HasFieldReference.FromSchema).fieldName,
+        )
+        assertEquals(
+            BsonAnyOf(BsonNull, BsonBoolean),
+            (secondEq.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant).type,
+        )
+        assertEquals(
+            false,
+            (secondEq.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant).value
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import static com.mongodb.client.model.Filters.*;
+
+public class Repository {
+    private final MongoClient client;
+
+    public Repository(MongoClient client) {
+        this.client = client;
+    }
+    
+    private Bson getAnd() {
+        var released = eq("released", true);
+        var notHidden = eq("hidden", false);
+        return and(released, notHidden);
+    }
+
+    public FindIterable<Document> findReleasedBooks() {
+        return client.getDatabase("myDatabase")
+                .getCollection("myCollection")
+                .find(getAnd());
+    }
+}
+        """,
+    )
+    fun `supports filters built with Filters#and using varargs arguments returned from a method call`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Repository", "findReleasedBooks")
+        val parsedQuery = JavaDriverDialect.parser.parse(query)
+
+        val hasChildren =
+            parsedQuery.component<HasFilter<Unit?>>()!!
+
+        val and = hasChildren.children[0]
+        assertEquals(Name.AND, and.component<Named>()!!.name)
+        val andChildren = and.component<HasFilter<Unit?>>()!!
+
+        val firstEq = andChildren.children[0]
+        assertEquals(
+            "released",
+            (firstEq.component<HasFieldReference<Unit?>>()!!.reference as HasFieldReference.FromSchema).fieldName,
+        )
+        assertEquals(
+            BsonAnyOf(BsonNull, BsonBoolean),
+            (firstEq.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant).type,
+        )
+        assertEquals(
+            true,
+            (firstEq.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant).value
+        )
+
+        val secondEq = andChildren.children[1]
+        assertEquals(
+            "hidden",
+            (secondEq.component<HasFieldReference<Unit?>>()!!.reference as HasFieldReference.FromSchema).fieldName,
+        )
+        assertEquals(
+            BsonAnyOf(BsonNull, BsonBoolean),
+            (secondEq.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant).type,
+        )
+        assertEquals(
+            false,
+            (secondEq.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant).value
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import org.bson.Document;
+import static com.mongodb.client.model.Filters.*;
+
+public class Repository {
+    private final MongoClient client;
+
+    public Repository(MongoClient client) {
+        this.client = client;
+    }
+
+    public FindIterable<Document> findReleasedBooks() {
+        return client.getDatabase("myDatabase")
+                .getCollection("myCollection")
+                .find(or(eq("released", true), eq("hidden", false)));
+    }
+}
+        """,
+    )
+    fun `supports filters built with Filters#or using varargs arguments`(psiFile: PsiFile) {
+        val query = psiFile.getQueryAtMethod("Repository", "findReleasedBooks")
+        val parsedQuery = JavaDriverDialect.parser.parse(query)
+
+        val hasFilter = parsedQuery.component<HasFilter<Unit?>>()!!
+
+        val and = hasFilter.children[0]
+        assertEquals(Name.OR, and.component<Named>()!!.name)
+        val andChildren = and.component<HasFilter<Unit?>>()!!
+
+        val firstEq = andChildren.children[0]
+        assertEquals(
+            "released",
+            (firstEq.component<HasFieldReference<Unit?>>()!!.reference as HasFieldReference.FromSchema).fieldName,
+        )
+        assertEquals(
+            BsonAnyOf(BsonNull, BsonBoolean),
+            (firstEq.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant).type,
+        )
+        assertEquals(
+            true,
+            (firstEq.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant).value
+        )
+
+        val secondEq = andChildren.children[1]
+        assertEquals(
+            "hidden",
+            (secondEq.component<HasFieldReference<Unit?>>()!!.reference as HasFieldReference.FromSchema).fieldName,
+        )
+        assertEquals(
+            BsonAnyOf(BsonNull, BsonBoolean),
+            (secondEq.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant).type,
+        )
+        assertEquals(
+            false,
+            (secondEq.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant).value
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import org.bson.Document;
+import static com.mongodb.client.model.Filters.*;
+
+public class Repository {
+    private final MongoClient client;
+
+    public Repository(MongoClient client) {
+        this.client = client;
+    }
+
+    public FindIterable<Document> findReleasedBooks() {
+        var released = eq("released", true);
+        var notHidden = eq("hidden", false);
+        var query = or(released, notHidden);
+        
+        return client.getDatabase("myDatabase")
+                .getCollection("myCollection")
+                .find(query);
+    }
+}
+        """,
+    )
+    fun `supports filters built with Filters#or using varargs arguments passed as a variable`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Repository", "findReleasedBooks")
+        val parsedQuery = JavaDriverDialect.parser.parse(query)
+
+        val hasChildren =
+            parsedQuery.component<HasFilter<Unit?>>()!!
+
+        val and = hasChildren.children[0]
+        assertEquals(Name.OR, and.component<Named>()!!.name)
+        val andChildren = and.component<HasFilter<Unit?>>()!!
+
+        val firstEq = andChildren.children[0]
+        assertEquals(
+            "released",
+            (firstEq.component<HasFieldReference<Unit?>>()!!.reference as HasFieldReference.FromSchema).fieldName,
+        )
+        assertEquals(
+            BsonAnyOf(BsonNull, BsonBoolean),
+            (firstEq.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant).type,
+        )
+        assertEquals(
+            true,
+            (firstEq.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant).value
+        )
+
+        val secondEq = andChildren.children[1]
+        assertEquals(
+            "hidden",
+            (secondEq.component<HasFieldReference<Unit?>>()!!.reference as HasFieldReference.FromSchema).fieldName,
+        )
+        assertEquals(
+            BsonAnyOf(BsonNull, BsonBoolean),
+            (secondEq.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant).type,
+        )
+        assertEquals(
+            false,
+            (secondEq.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant).value
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import static com.mongodb.client.model.Filters.*;
+
+public class Repository {
+    private final MongoClient client;
+
+    public Repository(MongoClient client) {
+        this.client = client;
+    }
+    
+    private Bson getOr() {
+        var released = eq("released", true);
+        var notHidden = eq("hidden", false);
+        return or(released, notHidden);
+    }
+
+    public FindIterable<Document> findReleasedBooks() {
+        return client.getDatabase("myDatabase")
+                .getCollection("myCollection")
+                .find(getOr());
+    }
+}
+        """,
+    )
+    fun `supports filters built with Filters#or using varargs arguments returned from a method call`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Repository", "findReleasedBooks")
+        val parsedQuery = JavaDriverDialect.parser.parse(query)
+
+        val hasChildren =
+            parsedQuery.component<HasFilter<Unit?>>()!!
+
+        val and = hasChildren.children[0]
+        assertEquals(Name.OR, and.component<Named>()!!.name)
+        val andChildren = and.component<HasFilter<Unit?>>()!!
+
+        val firstEq = andChildren.children[0]
+        assertEquals(
+            "released",
+            (firstEq.component<HasFieldReference<Unit?>>()!!.reference as HasFieldReference.FromSchema).fieldName,
+        )
+        assertEquals(
+            BsonAnyOf(BsonNull, BsonBoolean),
+            (firstEq.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant).type,
+        )
+        assertEquals(
+            true,
+            (firstEq.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant).value
+        )
+
+        val secondEq = andChildren.children[1]
+        assertEquals(
+            "hidden",
+            (secondEq.component<HasFieldReference<Unit?>>()!!.reference as HasFieldReference.FromSchema).fieldName,
+        )
+        assertEquals(
+            BsonAnyOf(BsonNull, BsonBoolean),
+            (secondEq.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant).type,
+        )
+        assertEquals(
+            false,
+            (secondEq.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant).value
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import org.bson.Document;
+import static com.mongodb.client.model.Filters.*;
+
+public class Repository {
+    private final MongoClient client;
+
+    public Repository(MongoClient client) {
+        this.client = client;
+    }
+
+    public FindIterable<Document> findReleasedBooks() {
+        return client.getDatabase("myDatabase")
+                .getCollection("myCollection")
+                .find(nor(eq("released", true), eq("hidden", false)));
+    }
+}
+        """,
+    )
+    fun `supports filters built with Filters#nor using varargs arguments`(psiFile: PsiFile) {
+        val query = psiFile.getQueryAtMethod("Repository", "findReleasedBooks")
+        val parsedQuery = JavaDriverDialect.parser.parse(query)
+
+        val hasFilter = parsedQuery.component<HasFilter<Unit?>>()!!
+
+        val and = hasFilter.children[0]
+        assertEquals(Name.NOR, and.component<Named>()!!.name)
+        val andChildren = and.component<HasFilter<Unit?>>()!!
+
+        val firstEq = andChildren.children[0]
+        assertEquals(
+            "released",
+            (firstEq.component<HasFieldReference<Unit?>>()!!.reference as HasFieldReference.FromSchema).fieldName,
+        )
+        assertEquals(
+            BsonAnyOf(BsonNull, BsonBoolean),
+            (firstEq.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant).type,
+        )
+        assertEquals(
+            true,
+            (firstEq.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant).value
+        )
+
+        val secondEq = andChildren.children[1]
+        assertEquals(
+            "hidden",
+            (secondEq.component<HasFieldReference<Unit?>>()!!.reference as HasFieldReference.FromSchema).fieldName,
+        )
+        assertEquals(
+            BsonAnyOf(BsonNull, BsonBoolean),
+            (secondEq.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant).type,
+        )
+        assertEquals(
+            false,
+            (secondEq.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant).value
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import org.bson.Document;
+import static com.mongodb.client.model.Filters.*;
+
+public class Repository {
+    private final MongoClient client;
+
+    public Repository(MongoClient client) {
+        this.client = client;
+    }
+
+    public FindIterable<Document> findReleasedBooks() {
+        var released = eq("released", true);
+        var notHidden = eq("hidden", false);
+        var query = nor(released, notHidden);
+        
+        return client.getDatabase("myDatabase")
+                .getCollection("myCollection")
+                .find(query);
+    }
+}
+        """,
+    )
+    fun `supports filters built with Filters#nor using varargs arguments passed as a variable`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Repository", "findReleasedBooks")
+        val parsedQuery = JavaDriverDialect.parser.parse(query)
+
+        val hasChildren =
+            parsedQuery.component<HasFilter<Unit?>>()!!
+
+        val and = hasChildren.children[0]
+        assertEquals(Name.NOR, and.component<Named>()!!.name)
+        val andChildren = and.component<HasFilter<Unit?>>()!!
+
+        val firstEq = andChildren.children[0]
+        assertEquals(
+            "released",
+            (firstEq.component<HasFieldReference<Unit?>>()!!.reference as HasFieldReference.FromSchema).fieldName,
+        )
+        assertEquals(
+            BsonAnyOf(BsonNull, BsonBoolean),
+            (firstEq.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant).type,
+        )
+        assertEquals(
+            true,
+            (firstEq.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant).value
+        )
+
+        val secondEq = andChildren.children[1]
+        assertEquals(
+            "hidden",
+            (secondEq.component<HasFieldReference<Unit?>>()!!.reference as HasFieldReference.FromSchema).fieldName,
+        )
+        assertEquals(
+            BsonAnyOf(BsonNull, BsonBoolean),
+            (secondEq.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant).type,
+        )
+        assertEquals(
+            false,
+            (secondEq.component<HasValueReference<PsiElement>>()!!.reference as HasValueReference.Constant).value
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import static com.mongodb.client.model.Filters.*;
+
+public class Repository {
+    private final MongoClient client;
+
+    public Repository(MongoClient client) {
+        this.client = client;
+    }
+    
+    private Bson getNor() {
+        var released = eq("released", true);
+        var notHidden = eq("hidden", false);
+        return nor(released, notHidden);
+    }
+
+    public FindIterable<Document> findReleasedBooks() {
+        return client.getDatabase("myDatabase")
+                .getCollection("myCollection")
+                .find(getNor());
+    }
+}
+        """,
+    )
+    fun `supports filters built with Filters#nor using varargs arguments returned from a method call`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Repository", "findReleasedBooks")
+        val parsedQuery = JavaDriverDialect.parser.parse(query)
+
+        val hasChildren =
+            parsedQuery.component<HasFilter<Unit?>>()!!
+
+        val and = hasChildren.children[0]
+        assertEquals(Name.NOR, and.component<Named>()!!.name)
         val andChildren = and.component<HasFilter<Unit?>>()!!
 
         val firstEq = andChildren.children[0]


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER-IF-ANY>

  eg. fix(type-hint): infer type of a constant for type checking INTELLIJ-1111
-->

## Description
The key change is just around using `PsiMethodCallExpression.getVarArgsOrIterableArgs()` for resolving correct arguments, the rest of the changes are just specific tests that I added for better coverage.

<!--- Describe your changes in detail so reviewers have enough content on what this PR aims to achieve -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist

- [ ] New tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
- [ ] Changelog is updated accordingly.
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement).

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->