### PR TITLE
chore: fixes docker install step and failing build info test

### DIFF
--- a/.github/workflows/quality-check.yaml
+++ b/.github/workflows/quality-check.yaml
@@ -148,8 +148,23 @@ jobs:
 
       - name: Setup Docker (for Test Containers)
         run: |
-          sudo apt update -y
-          sudo apt install -y docker docker-compose
+          echo "Adding Docker official GPG key"
+          sudo apt-get update
+          sudo apt-get install ca-certificates curl
+          sudo install -m 0755 -d /etc/apt/keyrings
+          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+          sudo chmod a+r /etc/apt/keyrings/docker.asc
+          
+          echo "Adding the repository to APT sources"
+          echo \
+          "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+          $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+          sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update
+
+          echo "Installing docker"
+          sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin
+
 
       - name: Run Test Suite
         run: |

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/observability/probe/NewConnectionActivatedProbeTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/observability/probe/NewConnectionActivatedProbeTest.kt
@@ -68,7 +68,7 @@ internal abstract class NewConnectionActivatedProbeTest(
                     event.properties[TelemetryProperty.IS_LOCALHOST] == isLocalhost &&
                     event.properties[TelemetryProperty.IS_ENTERPRISE] == isEnterprise &&
                     event.properties[TelemetryProperty.IS_GENUINE] == isGenuine &&
-                    event.properties[TelemetryProperty.VERSION] == version &&
+                    event.properties[TelemetryProperty.VERSION].toString().startsWith(version) &&
                     !event.properties.containsKey(TelemetryProperty.ATLAS_HOST)
             },
         )
@@ -83,7 +83,9 @@ internal class NewConnectionActivatedProbeTestForLocalEnvironment :
         isLocalhost = true,
         isEnterprise = false,
         isGenuine = true,
-        version = "7.0.15",
+        // not having an exact version here because then we'd have to keep it updated with every
+        // mongodb release
+        version = "7.0.",
     )
 
 @RequiresMongoDbCluster(
@@ -97,5 +99,7 @@ internal class NewConnectionActivatedProbeTestForAtlasCliEnvironment :
         isLocalhost = true,
         isEnterprise = true,
         isGenuine = true,
-        version = "7.0.15",
+        // not having an exact version here because then we'd have to keep it updated with every
+        // mongodb release
+        version = "7.0.",
     )


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER-IF-ANY>

  eg. fix(type-hint): infer type of a constant for type checking INTELLIJ-1111
-->

## Description
Looks like the installation target is either removed or renamed and we can't install docker just with the name docker. I am using the recommended steps in Docker's [install documentation](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository) to set up the install step.

For the failing test, I changed from strict version comparison to a loose comparison using `String.startsWith`. This should remove the work of keeping this number updated across different releases of mongodb server.

<!--- Describe your changes in detail so reviewers have enough content on what this PR aims to achieve -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist

- [ ] New tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
- [ ] Changelog is updated accordingly.
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement).

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->