### PR TITLE
feat: add support for parsing, inspecting and autocompleting in an aggregation and a match stage written using Spring Data MongoDB INTELLIJ-172

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ MongoDB plugin for IntelliJ IDEA.
 ## [Unreleased]
 
 ### Added
+* [INTELLIJ-172](https://jira.mongodb.org/browse/INTELLIJ-172) Add support for parsing and inspecting an aggregation and a match stage written in Spring Criteria
 * [INTELLIJ-178](https://jira.mongodb.org/browse/INTELLIJ-178) Telemetry when the Run Query button is clicked.
   It can be disabled in the Plugin settings.
 * [INTELLIJ-153](https://jira.mongodb.org/browse/INTELLIJ-153) Add support for parsing, linting and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ MongoDB plugin for IntelliJ IDEA.
 ## [Unreleased]
 
 ### Added
-* [INTELLIJ-172](https://jira.mongodb.org/browse/INTELLIJ-172) Add support for parsing and inspecting an aggregation and a match stage written in Spring Data MongoDB.
+* [INTELLIJ-172](https://jira.mongodb.org/browse/INTELLIJ-172) Add support for parsing, inspecting and autocompleting in an aggregation written using Spring Data MongoDB (`MongoTemplate.aggregate`, `MongoTemplate.aggregateStream`) and a match stage written using `Aggregation.match`.
 * [INTELLIJ-179](https://jira.mongodb.org/browse/INTELLIJ-179) Telemetry when Create Index intention is clicked.
   It can be disabled in the Plugin settings.
 * [INTELLIJ-178](https://jira.mongodb.org/browse/INTELLIJ-178) Telemetry when the Run Query button is clicked.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ MongoDB plugin for IntelliJ IDEA.
 ## [Unreleased]
 
 ### Added
-* [INTELLIJ-172](https://jira.mongodb.org/browse/INTELLIJ-172) Add support for parsing and inspecting an aggregation and a match stage written in Spring Criteria
+* [INTELLIJ-172](https://jira.mongodb.org/browse/INTELLIJ-172) Add support for parsing and inspecting an aggregation and a match stage written in Spring Data MongoDB.
 * [INTELLIJ-179](https://jira.mongodb.org/browse/INTELLIJ-179) Telemetry when Create Index intention is clicked.
   It can be disabled in the Plugin settings.
 * [INTELLIJ-178](https://jira.mongodb.org/browse/INTELLIJ-178) Telemetry when the Run Query button is clicked.

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/SpringCriteriaCompletionContributorTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/SpringCriteriaCompletionContributorTest.kt
@@ -57,7 +57,6 @@ record Book() {}
         )
     }
 
-    @Suppress("TOO_LONG_FUNCTION")
     @ParsingTest(
         fileName = "Repository.java",
         value = """
@@ -86,6 +85,275 @@ class Repository {
         """,
     )
     fun `should autocomplete fields from the current namespace`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(Aggregation.newAggregation(), "<caret>"
+    }
+}
+        """,
+    )
+    fun `should autocomplete collections from the current connection in an aggregate call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(ListCollections.Slice("myDatabase")))
+        ).thenReturn(
+            ListCollections(
+                listOf(
+                    ListCollections.Collection("myCollection", "collection"),
+                    ListCollections.Collection("anotherCollection", "collection"),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myCollection"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "anotherCollection"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregateStream(Aggregation.newAggregation(), "<caret>"
+    }
+}
+        """,
+    )
+    fun `should autocomplete collections from the current connection in an aggregateStream call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(ListCollections.Slice("myDatabase")))
+        ).thenReturn(
+            ListCollections(
+                listOf(
+                    ListCollections.Collection("myCollection", "collection"),
+                    ListCollections.Collection("anotherCollection", "collection"),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myCollection"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "anotherCollection"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.match(where("<caret>"))
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in a Criteria inside an aggregate call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregateStream(
+            Aggregation.newAggregation(
+                Aggregation.match(where("<caret>"))
+            ),
+            Book.class,
+            Book.class
+        ).toList();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in a Criteria inside an aggregateStream call`(
         fixture: CodeInsightTestFixture,
     ) {
         val (dataSource, readModelProvider) = fixture.setupConnection()

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/SpringCriteriaMongoDbAutocompletionPopupHandlerTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/SpringCriteriaMongoDbAutocompletionPopupHandlerTest.kt
@@ -59,7 +59,6 @@ record Book() {}
         )
     }
 
-    @Suppress("TOO_LONG_FUNCTION")
     @ParsingTest(
         fileName = "Repository.java",
         value = """
@@ -88,6 +87,279 @@ class Repository {
         """,
     )
     fun `should autocomplete fields from the current namespace`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        fixture.type('"')
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(Aggregation.newAggregation(), <caret>
+    }
+}
+        """,
+    )
+    fun `should autocomplete collections from the current connection in an aggregate call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(ListCollections.Slice("myDatabase")))
+        ).thenReturn(
+            ListCollections(
+                listOf(
+                    ListCollections.Collection("myCollection", "collection"),
+                    ListCollections.Collection("anotherCollection", "collection"),
+                ),
+            ),
+        )
+
+        fixture.type('"')
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myCollection"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "anotherCollection"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregateStream(Aggregation.newAggregation(), <caret>
+    }
+}
+        """,
+    )
+    fun `should autocomplete collections from the current connection in an aggregateStream call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(ListCollections.Slice("myDatabase")))
+        ).thenReturn(
+            ListCollections(
+                listOf(
+                    ListCollections.Collection("myCollection", "collection"),
+                    ListCollections.Collection("anotherCollection", "collection"),
+                ),
+            ),
+        )
+
+        fixture.type('"')
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myCollection"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "anotherCollection"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.match(where(<caret>))
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in a Criteria inside an aggregate call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        fixture.type('"')
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregateStream(
+            Aggregation.newAggregation(
+                Aggregation.match(where(<caret>))
+            ),
+            Book.class,
+            Book.class
+        ).toList();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in a Criteria inside an aggregateStream call`(
         fixture: CodeInsightTestFixture,
     ) {
         val (dataSource, readModelProvider) = fixture.setupConnection()

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/impl/SpringCriteriaFieldCheckLinterInspectionTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/impl/SpringCriteriaFieldCheckLinterInspectionTest.kt
@@ -27,6 +27,7 @@ class SpringCriteriaFieldCheckLinterInspectionTest {
         fileName = "Repository.java",
         value = """
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import static org.springframework.data.mongodb.core.query.Query.query;
@@ -50,6 +51,18 @@ class BookRepository {
             Book.class
         )</warning>;
     }
+    
+    public void allReleasedBooksAggregate() {
+        <warning descr="No connection available to run this check.">template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.match(
+                    where("released").is(true)
+                )
+            ),
+            Book.class,
+            Book.class
+        )</warning>;
+    }
 }
         """,
     )
@@ -65,6 +78,7 @@ class BookRepository {
         fileName = "Repository.java",
         value = """
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import static org.springframework.data.mongodb.core.query.Query.query;
@@ -84,6 +98,18 @@ class BookRepository {
         <warning descr="No database selected to run this check.">template.find(
                 query(where("released").is(true)),
                 Book.class
+        )</warning>;
+    }
+    
+    public void allReleasedBooksAggregate() {
+        <warning descr="No database selected to run this check.">template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.match(
+                    where("released").is(true)
+                )
+            ),
+            Book.class,
+            Book.class
         )</warning>;
     }
 }
@@ -141,6 +167,7 @@ class BookRepository {
         fileName = "Repository.java",
         value = """
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import static org.springframework.data.mongodb.core.query.Query.query;
@@ -160,6 +187,18 @@ class BookRepository {
         template.find(
                 query(where(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">"released"</warning>).is(true)),
                 Book.class
+        );
+    }
+    
+    public void allReleasedBooksAggregate() {
+        template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.match(
+                    where(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">"released"</warning>).is(true)
+                )
+            ),
+            Book.class,
+            Book.class
         );
     }
 }
@@ -222,6 +261,7 @@ class BookRepository {
         fileName = "Repository.java",
         value = """
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import static org.springframework.data.mongodb.core.query.Query.query;
@@ -241,6 +281,18 @@ class BookRepository {
         template.find(
                 query(where("released").is(<warning descr="A \"String\"(type of provided value) cannot be assigned to \"boolean\"(type of \"released\")">"true"</warning>)),
                 Book.class
+        );
+    }
+    
+    public void allReleasedBooksAggregate() {
+        template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.match(
+                    where("released").is(<warning descr="A \"String\"(type of provided value) cannot be assigned to \"boolean\"(type of \"released\")">"true"</warning>)
+                )
+            ),
+            Book.class,
+            Book.class
         );
     }
 }
@@ -306,6 +358,7 @@ class BookRepository {
         fileName = "Repository.java",
         value = """
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import static org.springframework.data.mongodb.core.query.Query.query;
@@ -325,6 +378,18 @@ class BookRepository {
         template.find(
                 query(where("released").is("true")),
                 Book.class
+        );
+    }
+    
+    public void allReleasedBooksAggregate() {
+        template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.match(
+                    where("released").is("true")
+                )
+            ),
+            Book.class,
+            Book.class
         );
     }
 }

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/impl/SpringCriteriaNamespaceCheckLinterInspectionTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/impl/SpringCriteriaNamespaceCheckLinterInspectionTest.kt
@@ -9,12 +9,6 @@ import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 
-// Suppressing
-// - LONG_LINE because the complaint is about the templated error description which needs to be in the same line for the
-// match to happen correctly
-// - TOO_LONG_FUNCTION because it is better to keep test logic within the tests and not make them "too smart" otherwise
-// reading through them becomes a task in its own
-@Suppress("LONG_LINE", "TOO_LONG_FUNCTION")
 @CodeInsightTest
 class SpringCriteriaNamespaceCheckLinterInspectionTest {
     @ParsingTest(
@@ -48,6 +42,71 @@ class BookRepository {
         """,
     )
     fun `shows an inspection when the collection does not exist in the current data source`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDb")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        `when`(readModelProvider.slice(eq(dataSource), eq(ListDatabases.Slice))).thenReturn(
+            ListDatabases(listOf(ListDatabases.Database("myDb")))
+        )
+
+        `when`(readModelProvider.slice(eq(dataSource), any<ListCollections.Slice>())).thenReturn(
+            ListCollections(emptyList())
+        )
+
+        fixture.enableInspections(NamespaceCheckInspectionBridge::class.java)
+        fixture.testHighlighting()
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import static org.springframework.data.mongodb.core.query.Query.query;
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class BookRepository {
+    private final MongoTemplate template;
+
+    public BookRepository(MongoTemplate template) {
+        this.template = template;
+    }
+
+    public void allReleasedBooks() {
+        template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.match(
+                    where("released").is(true)
+                )
+            ),
+            <warning descr="Cannot resolve \"book\" collection in \"myDb\" database in the connected data source.">Book.class</warning>,
+            Book.class
+        );
+    }
+    
+    public void allReleasedBooksVariant2() {
+        template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.match(
+                    where("released").is(true)
+                )
+            ),
+            <warning descr="Cannot resolve \"book\" collection in \"myDb\" database in the connected data source.">"book"</warning>,
+            Book.class
+        );
+    }
+}
+        """,
+    )
+    fun `shows an inspection when the collection does not exist in the current data source for an aggregation`(
         fixture: CodeInsightTestFixture,
     ) {
         val (dataSource, readModelProvider) = fixture.setupConnection()

--- a/packages/jetbrains-plugin/src/test/resources/project-fixtures/basic-java-project-with-mongodb/src/main/java/alt/mongodb/springcriteria/BookRepository.java
+++ b/packages/jetbrains-plugin/src/test/resources/project-fixtures/basic-java-project-with-mongodb/src/main/java/alt/mongodb/springcriteria/BookRepository.java
@@ -1,6 +1,7 @@
 package alt.mongodb.springcriteria;
 
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.util.List;
@@ -19,5 +20,17 @@ class BookRepository {
 
     public List<Book> allReleasedBooks() {
         return template.query(Book.class).matching(where("released").is(true)).all();
+    }
+
+    public List<Book> allReleasedBooksAgg() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.match(
+                    where("released").is(true)
+                )
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
     }
 }

--- a/packages/jetbrains-plugin/src/test/resources/project-fixtures/basic-java-project-with-mongodb/src/main/java/alt/mongodb/springcriteria/SpringCriteriaRepository.java
+++ b/packages/jetbrains-plugin/src/test/resources/project-fixtures/basic-java-project-with-mongodb/src/main/java/alt/mongodb/springcriteria/SpringCriteriaRepository.java
@@ -1,6 +1,7 @@
 package alt.mongodb.springcriteria;
 
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.util.List;
@@ -26,6 +27,18 @@ public class SpringCriteriaRepository {
                 query(where( "tomatoes.viewer.rating").gte(rating)),
                 Movie.class
         );
+    }
+
+    private List<Movie> allMoviesWithRatingAtLeastAgg(int rating) {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.match(
+                    where( "tomatoes.viewer.rating").gte(rating)
+                )
+            ),
+            Movie.class,
+            Movie.class
+        ).getMappedResults();
     }
 
     private void updateLanguageOfAllMoviesWithRatingAtLeast(int rating, String newLanguage) {

--- a/packages/mongodb-dialects/spring-criteria/src/main/kotlin/com/mongodb/jbplugin/dialects/springcriteria/SpringCriteriaDialectParser.kt
+++ b/packages/mongodb-dialects/spring-criteria/src/main/kotlin/com/mongodb/jbplugin/dialects/springcriteria/SpringCriteriaDialectParser.kt
@@ -216,7 +216,7 @@ object SpringCriteriaDialectParser : DialectParser<PsiElement> {
                     )
                 )
             )
-            "aggregate" -> {
+            "aggregate", "aggregateStream" -> {
                 val expressions = mongoOpCall.argumentList.expressions
                 val newAggregationCall = expressions.getOrNull(0)?.resolveToMethodCallExpression {
                         _,

--- a/packages/mongodb-dialects/spring-criteria/src/test/kotlin/com/mongodb/jbplugin/dialects/springcriteria/IntegrationTest.kt
+++ b/packages/mongodb-dialects/spring-criteria/src/test/kotlin/com/mongodb/jbplugin/dialects/springcriteria/IntegrationTest.kt
@@ -35,6 +35,7 @@ import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
 import com.mongodb.assertions.Assertions.assertNotNull
 import com.mongodb.jbplugin.mql.Component
 import com.mongodb.jbplugin.mql.Node
+import com.mongodb.jbplugin.mql.components.HasAggregation
 import com.mongodb.jbplugin.mql.components.HasCollectionReference
 import com.mongodb.jbplugin.mql.components.HasFieldReference
 import com.mongodb.jbplugin.mql.components.HasFilter
@@ -296,6 +297,35 @@ fun Node<PsiElement>.assert(
 
     assertEquals(command, cmd!!.type)
     this.assertions()
+}
+
+fun Node<PsiElement>.stageN(
+    n: Int,
+    name: Name? = null,
+    assertions: Node<PsiElement>.() -> Unit = {
+    }
+) {
+    val stages = component<HasAggregation<PsiElement>>()?.children ?: emptyList()
+    assertNotEquals(0, stages.size) {
+        "Expected HasAggregation to have at-least $n stages"
+    }
+
+    val stage = stages.getOrNull(n)
+    assertNotEquals(null, stage) {
+        "Expected a stage at index $n, found null"
+    }
+
+    if (name != null) {
+        val stageName = stage!!.component<Named>()
+        assertNotEquals(null, stageName) {
+            "Expected a stage with name $name but null found."
+        }
+        assertEquals(name, stageName!!.name) {
+            "Expected a stage with name $name but ${stageName.name} found."
+        }
+    }
+
+    stage!!.assertions()
 }
 
 fun Node<PsiElement>.filterN(

--- a/packages/mongodb-dialects/spring-criteria/src/test/kotlin/com/mongodb/jbplugin/dialects/springcriteria/QueryTargetCollectionExtractorTest.kt
+++ b/packages/mongodb-dialects/spring-criteria/src/test/kotlin/com/mongodb/jbplugin/dialects/springcriteria/QueryTargetCollectionExtractorTest.kt
@@ -81,7 +81,7 @@ class Repository {
         val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
         val collection =
             (
-                QueryTargetCollectionExtractor.extractCollectionFromParameter(
+                QueryTargetCollectionExtractor.extractCollectionFromClassTypeParameter(
                     (query as? PsiMethodCallExpression)?.argumentList?.expressions?.getOrNull(1)
                 ).reference as HasCollectionReference.OnlyCollection
                 ).collection

--- a/packages/mongodb-dialects/spring-criteria/src/test/kotlin/com/mongodb/jbplugin/dialects/springcriteria/aggregationparser/AggregationParserTest.kt
+++ b/packages/mongodb-dialects/spring-criteria/src/test/kotlin/com/mongodb/jbplugin/dialects/springcriteria/aggregationparser/AggregationParserTest.kt
@@ -46,7 +46,7 @@ class Repository {
 }
         """
     )
-    fun `should be able to parse an empty aggregation with a class type provided for target collection`(
+    fun `should be able to parse an empty aggregation using aggregate call with a class type provided for target collection`(
         psiFile: PsiFile
     ) {
         val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
@@ -94,7 +94,103 @@ class Repository {
 }
         """
     )
-    fun `should be able to parse an empty aggregation with a string type provided for target collection`(
+    fun `should be able to parse an empty aggregation using aggregate call with a string type provided for target collection`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        SpringCriteriaDialectParser.parse(query).assert(IsCommand.CommandType.AGGREGATE) {
+            component<HasSourceDialect> {
+                assertEquals(HasSourceDialect.DialectName.SPRING_CRITERIA, name)
+            }
+
+            collection<HasCollectionReference.OnlyCollection<PsiElement>> {
+                assertEquals("booksAsString", collection)
+            }
+
+            component<HasAggregation<PsiElement>> {
+                assertEquals(0, children.size)
+            }
+        }
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        return template.aggregateStream(
+            Aggregation.newAggregation(),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse an empty aggregation using aggregateStream call with a class type provided for target collection`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        SpringCriteriaDialectParser.parse(query).assert(IsCommand.CommandType.AGGREGATE) {
+            component<HasSourceDialect> {
+                assertEquals(HasSourceDialect.DialectName.SPRING_CRITERIA, name)
+            }
+
+            collection<HasCollectionReference.OnlyCollection<PsiElement>> {
+                assertEquals("book", collection)
+            }
+
+            component<HasAggregation<PsiElement>> {
+                assertEquals(0, children.size)
+            }
+        }
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        return template.aggregateStream(
+            Aggregation.newAggregation(),
+            "booksAsString",
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse an empty aggregation using aggregateStream call with a string type provided for target collection`(
         psiFile: PsiFile
     ) {
         val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")

--- a/packages/mongodb-dialects/spring-criteria/src/test/kotlin/com/mongodb/jbplugin/dialects/springcriteria/aggregationparser/AggregationParserTest.kt
+++ b/packages/mongodb-dialects/spring-criteria/src/test/kotlin/com/mongodb/jbplugin/dialects/springcriteria/aggregationparser/AggregationParserTest.kt
@@ -1,0 +1,216 @@
+package com.mongodb.jbplugin.dialects.springcriteria.aggregationparser
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.mongodb.jbplugin.dialects.springcriteria.IntegrationTest
+import com.mongodb.jbplugin.dialects.springcriteria.ParsingTest
+import com.mongodb.jbplugin.dialects.springcriteria.SpringCriteriaDialectParser
+import com.mongodb.jbplugin.dialects.springcriteria.assert
+import com.mongodb.jbplugin.dialects.springcriteria.collection
+import com.mongodb.jbplugin.dialects.springcriteria.component
+import com.mongodb.jbplugin.dialects.springcriteria.getQueryAtMethod
+import com.mongodb.jbplugin.mql.components.HasAggregation
+import com.mongodb.jbplugin.mql.components.HasCollectionReference
+import com.mongodb.jbplugin.mql.components.HasSourceDialect
+import com.mongodb.jbplugin.mql.components.IsCommand
+import org.junit.jupiter.api.Assertions.assertEquals
+
+@IntegrationTest
+class AggregationParserTest {
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse an empty aggregation with a class type provided for target collection`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        SpringCriteriaDialectParser.parse(query).assert(IsCommand.CommandType.AGGREGATE) {
+            component<HasSourceDialect> {
+                assertEquals(HasSourceDialect.DialectName.SPRING_CRITERIA, name)
+            }
+
+            collection<HasCollectionReference.OnlyCollection<PsiElement>> {
+                assertEquals("book", collection)
+            }
+
+            component<HasAggregation<PsiElement>> {
+                assertEquals(0, children.size)
+            }
+        }
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(),
+            "booksAsString",
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse an empty aggregation with a string type provided for target collection`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        SpringCriteriaDialectParser.parse(query).assert(IsCommand.CommandType.AGGREGATE) {
+            component<HasSourceDialect> {
+                assertEquals(HasSourceDialect.DialectName.SPRING_CRITERIA, name)
+            }
+
+            collection<HasCollectionReference.OnlyCollection<PsiElement>> {
+                assertEquals("booksAsString", collection)
+            }
+
+            component<HasAggregation<PsiElement>> {
+                assertEquals(0, children.size)
+            }
+        }
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        Aggregation aggregation = Aggregation.newAggregation();
+        return template.aggregate(
+            aggregation,
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse an empty aggregation referenced as a variable`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        SpringCriteriaDialectParser.parse(query).assert(IsCommand.CommandType.AGGREGATE) {
+            component<HasSourceDialect> {
+                assertEquals(HasSourceDialect.DialectName.SPRING_CRITERIA, name)
+            }
+
+            collection<HasCollectionReference.OnlyCollection<PsiElement>> {
+                assertEquals("book", collection)
+            }
+
+            component<HasAggregation<PsiElement>> {
+                assertEquals(0, children.size)
+            }
+        }
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    private Aggregation getAggregation() {
+        return Aggregation.newAggregation();
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        return template.aggregate(
+            getAggregation(),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse an empty aggregation referenced as a return value from a method`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        SpringCriteriaDialectParser.parse(query).assert(IsCommand.CommandType.AGGREGATE) {
+            component<HasSourceDialect> {
+                assertEquals(HasSourceDialect.DialectName.SPRING_CRITERIA, name)
+            }
+
+            collection<HasCollectionReference.OnlyCollection<PsiElement>> {
+                assertEquals("book", collection)
+            }
+
+            component<HasAggregation<PsiElement>> {
+                assertEquals(0, children.size)
+            }
+        }
+    }
+}

--- a/packages/mongodb-dialects/spring-criteria/src/test/kotlin/com/mongodb/jbplugin/dialects/springcriteria/aggregationparser/MatchStageParserTest.kt
+++ b/packages/mongodb-dialects/spring-criteria/src/test/kotlin/com/mongodb/jbplugin/dialects/springcriteria/aggregationparser/MatchStageParserTest.kt
@@ -1,0 +1,960 @@
+package com.mongodb.jbplugin.dialects.springcriteria.aggregationparser
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.mongodb.jbplugin.dialects.springcriteria.IntegrationTest
+import com.mongodb.jbplugin.dialects.springcriteria.ParsingTest
+import com.mongodb.jbplugin.dialects.springcriteria.SpringCriteriaDialectParser
+import com.mongodb.jbplugin.dialects.springcriteria.assert
+import com.mongodb.jbplugin.dialects.springcriteria.caret
+import com.mongodb.jbplugin.dialects.springcriteria.collection
+import com.mongodb.jbplugin.dialects.springcriteria.component
+import com.mongodb.jbplugin.dialects.springcriteria.field
+import com.mongodb.jbplugin.dialects.springcriteria.filterN
+import com.mongodb.jbplugin.dialects.springcriteria.getQueryAtMethod
+import com.mongodb.jbplugin.dialects.springcriteria.stageN
+import com.mongodb.jbplugin.dialects.springcriteria.value
+import com.mongodb.jbplugin.mql.BsonAnyOf
+import com.mongodb.jbplugin.mql.BsonArray
+import com.mongodb.jbplugin.mql.BsonBoolean
+import com.mongodb.jbplugin.mql.BsonNull
+import com.mongodb.jbplugin.mql.components.HasCollectionReference
+import com.mongodb.jbplugin.mql.components.HasFieldReference
+import com.mongodb.jbplugin.mql.components.HasFilter
+import com.mongodb.jbplugin.mql.components.HasSourceDialect
+import com.mongodb.jbplugin.mql.components.HasValueReference
+import com.mongodb.jbplugin.mql.components.IsCommand
+import com.mongodb.jbplugin.mql.components.Name
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Disabled
+
+@IntegrationTest
+class MatchStageParserTest {
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.match()
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse an empty match stage`(psiFile: PsiFile) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        SpringCriteriaDialectParser.parse(query).assert(IsCommand.CommandType.AGGREGATE) {
+            component<HasSourceDialect> {
+                assertEquals(HasSourceDialect.DialectName.SPRING_CRITERIA, name)
+            }
+
+            collection<HasCollectionReference.OnlyCollection<PsiElement>> {
+                assertEquals("book", collection)
+            }
+
+            stageN(0, Name.MATCH) {
+                component<HasFilter<PsiElement>> {
+                    assertEquals(0, children.size)
+                }
+            }
+        }
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.MatchOperation;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        MatchOperation matchStage = Aggregation.match();
+        return template.aggregate(
+            Aggregation.newAggregation(
+                matchStage
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse an empty match stage referenced as a variable`(psiFile: PsiFile) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        SpringCriteriaDialectParser.parse(query).assert(IsCommand.CommandType.AGGREGATE) {
+            component<HasSourceDialect> {
+                assertEquals(HasSourceDialect.DialectName.SPRING_CRITERIA, name)
+            }
+
+            collection<HasCollectionReference.OnlyCollection<PsiElement>> {
+                assertEquals("book", collection)
+            }
+
+            stageN(0, Name.MATCH) {
+                component<HasFilter<PsiElement>> {
+                    assertEquals(0, children.size)
+                }
+            }
+        }
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.MatchOperation;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    private MatchOperation getMatchStage() {
+        return Aggregation.match();
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                getMatchStage()
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse an empty match stage referenced as a method call`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        SpringCriteriaDialectParser.parse(query).assert(IsCommand.CommandType.AGGREGATE) {
+            component<HasSourceDialect> {
+                assertEquals(HasSourceDialect.DialectName.SPRING_CRITERIA, name)
+            }
+
+            collection<HasCollectionReference.OnlyCollection<PsiElement>> {
+                assertEquals("book", collection)
+            }
+
+            stageN(0, Name.MATCH) {
+                component<HasFilter<PsiElement>> {
+                    assertEquals(0, children.size)
+                }
+            }
+        }
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.match(
+                    Criteria.where("released").is(true)
+                )
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse a match stage provided with a Criteria (eq)`(psiFile: PsiFile) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        SpringCriteriaDialectParser.parse(query).assert(IsCommand.CommandType.AGGREGATE) {
+            component<HasSourceDialect> {
+                assertEquals(HasSourceDialect.DialectName.SPRING_CRITERIA, name)
+            }
+
+            collection<HasCollectionReference.OnlyCollection<PsiElement>> {
+                assertEquals("book", collection)
+            }
+
+            stageN(0, Name.MATCH) {
+                assertEquals(1, component<HasFilter<PsiElement>>()?.children?.size) {
+                    "Expected at-least 1 filter, found ${component<HasFilter<PsiElement>>()?.children?.size}"
+                }
+
+                filterN(0, Name.EQ) {
+                    field<HasFieldReference.FromSchema<PsiElement>> {
+                        assertEquals("released", fieldName)
+                    }
+                    value<HasValueReference.Constant<PsiElement>> {
+                        assertEquals(BsonAnyOf(BsonNull, BsonBoolean), type)
+                        assertEquals(true, value)
+                    }
+                }
+            }
+        }
+    }
+
+    @Disabled("We do not yet support criteria referenced as a variable")
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.MatchOperation;import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        Criteria criteria = Criteria.where("released").is(true);
+        MatchOperation matchStage = Aggregation.match(
+            criteria
+        );
+        return template.aggregate(
+            Aggregation.newAggregation(
+                matchStage
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse a match stage provided with a Criteria as a variable`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        val parsedQuery = SpringCriteriaDialectParser.parse(query)
+        SpringCriteriaDialectParser.parse(query).assert(IsCommand.CommandType.AGGREGATE) {
+            component<HasSourceDialect> {
+                assertEquals(HasSourceDialect.DialectName.SPRING_CRITERIA, name)
+            }
+
+            collection<HasCollectionReference.OnlyCollection<PsiElement>> {
+                assertEquals("book", collection)
+            }
+
+            stageN(0, Name.MATCH) {
+                assertEquals(1, component<HasFilter<PsiElement>>()?.children?.size) {
+                    "Expected at-least 1 filter, found ${component<HasFilter<PsiElement>>()?.children?.size}"
+                }
+
+                filterN(0, Name.EQ) {
+                    field<HasFieldReference.FromSchema<PsiElement>> {
+                        assertEquals("released", fieldName)
+                    }
+                    value<HasValueReference.Constant<PsiElement>> {
+                        assertEquals(BsonAnyOf(BsonNull, BsonBoolean), type)
+                        assertEquals(true, value)
+                    }
+                }
+            }
+        }
+    }
+
+    @Disabled("We do not yet support criteria referenced as a method call")
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.MatchOperation;import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    private Criteria getCriteria() {
+        return Criteria.where("released").is(true);
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        MatchOperation matchStage = Aggregation.match(
+            getCriteria()
+        );
+        return template.aggregate(
+            Aggregation.newAggregation(
+                matchStage
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse a match stage provided with a Criteria as a method call`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        val parsedQuery = SpringCriteriaDialectParser.parse(query)
+        SpringCriteriaDialectParser.parse(query).assert(IsCommand.CommandType.AGGREGATE) {
+            component<HasSourceDialect> {
+                assertEquals(HasSourceDialect.DialectName.SPRING_CRITERIA, name)
+            }
+
+            collection<HasCollectionReference.OnlyCollection<PsiElement>> {
+                assertEquals("book", collection)
+            }
+
+            stageN(0, Name.MATCH) {
+                assertEquals(1, component<HasFilter<PsiElement>>()?.children?.size) {
+                    "Expected at-least 1 filter, found ${component<HasFilter<PsiElement>>()?.children?.size}"
+                }
+
+                filterN(0, Name.EQ) {
+                    field<HasFieldReference.FromSchema<PsiElement>> {
+                        assertEquals("released", fieldName)
+                    }
+                    value<HasValueReference.Constant<PsiElement>> {
+                        assertEquals(BsonAnyOf(BsonNull, BsonBoolean), type)
+                        assertEquals(true, value)
+                    }
+                }
+            }
+        }
+    }
+
+    @Disabled("We do not yet support criteria built with new Criteria() calls")
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.match(new Criteria("released").is(true))
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse a match stage provided with a Criteria built with Criteria constructor calls`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        SpringCriteriaDialectParser.parse(query).assert(IsCommand.CommandType.AGGREGATE) {
+            component<HasSourceDialect> {
+                assertEquals(HasSourceDialect.DialectName.SPRING_CRITERIA, name)
+            }
+
+            collection<HasCollectionReference.OnlyCollection<PsiElement>> {
+                assertEquals("book", collection)
+            }
+
+            stageN(0, Name.MATCH) {
+                assertEquals(1, component<HasFilter<PsiElement>>()?.children?.size) {
+                    "Expected at-least 1 filter, found ${component<HasFilter<PsiElement>>()?.children?.size}"
+                }
+
+                filterN(0, Name.EQ) {
+                    field<HasFieldReference.FromSchema<PsiElement>> {
+                        assertEquals("released", fieldName)
+                    }
+                    value<HasValueReference.Constant<PsiElement>> {
+                        assertEquals(BsonAnyOf(BsonNull, BsonBoolean), type)
+                        assertEquals(true, value)
+                    }
+                }
+            }
+        }
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.match(
+                    Criteria.where("released").is(true).and("hidden").is(0)
+                )
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse a match stage provided with a Criteria having multiple fields`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        SpringCriteriaDialectParser.parse(query).assert(IsCommand.CommandType.AGGREGATE) {
+            component<HasSourceDialect> {
+                assertEquals(HasSourceDialect.DialectName.SPRING_CRITERIA, name)
+            }
+
+            collection<HasCollectionReference.OnlyCollection<PsiElement>> {
+                assertEquals("book", collection)
+            }
+
+            stageN(0, Name.MATCH) {
+                assertEquals(2, component<HasFilter<PsiElement>>()?.children?.size) {
+                    "Expected at-least 2 filters, found ${component<HasFilter<PsiElement>>()?.children?.size}"
+                }
+
+                filterN(0, Name.EQ) {
+                    field<HasFieldReference.FromSchema<PsiElement>> {
+                        assertEquals("hidden", fieldName)
+                    }
+                    value<HasValueReference.Constant<PsiElement>> { assertEquals(0, value) }
+                }
+
+                filterN(1, Name.EQ) {
+                    field<HasFieldReference.FromSchema<PsiElement>> {
+                        assertEquals("released", fieldName)
+                    }
+                    value<HasValueReference.Constant<PsiElement>> { assertEquals(true, value) }
+                }
+            }
+        }
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.match(
+                    Criteria.where("released").not().is(true)
+                )
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse a match stage provided with a Criteria (ne)`(psiFile: PsiFile) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        SpringCriteriaDialectParser.parse(query).assert(IsCommand.CommandType.AGGREGATE) {
+            component<HasSourceDialect> {
+                assertEquals(HasSourceDialect.DialectName.SPRING_CRITERIA, name)
+            }
+
+            collection<HasCollectionReference.OnlyCollection<PsiElement>> {
+                assertEquals("book", collection)
+            }
+
+            stageN(0, Name.MATCH) {
+                assertEquals(1, component<HasFilter<PsiElement>>()?.children?.size) {
+                    "Expected at-least 1 filter, found ${component<HasFilter<PsiElement>>()?.children?.size}"
+                }
+
+                filterN(0, Name.NOT) {
+                    filterN(0, Name.EQ) {
+                        field<HasFieldReference.FromSchema<PsiElement>> {
+                            assertEquals("released", fieldName)
+                        }
+                        value<HasValueReference.Constant<PsiElement>> { assertEquals(true, value) }
+                    }
+                }
+            }
+        }
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.match(
+                    Criteria.where("released").in(true, false)
+                )
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse a match stage provided with a Criteria (in)`(psiFile: PsiFile) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        SpringCriteriaDialectParser.parse(query).assert(IsCommand.CommandType.AGGREGATE) {
+            component<HasSourceDialect> {
+                assertEquals(HasSourceDialect.DialectName.SPRING_CRITERIA, name)
+            }
+
+            collection<HasCollectionReference.OnlyCollection<PsiElement>> {
+                assertEquals("book", collection)
+            }
+
+            stageN(0, Name.MATCH) {
+                assertEquals(1, component<HasFilter<PsiElement>>()?.children?.size) {
+                    "Expected at-least 1 filter, found ${component<HasFilter<PsiElement>>()?.children?.size}"
+                }
+
+                filterN(0, Name.IN) {
+                    field<HasFieldReference.FromSchema<PsiElement>> {
+                        assertEquals("released", fieldName)
+                    }
+                    value<HasValueReference.Constant<PsiElement>> {
+                        assertEquals(listOf(true, false), value)
+                        assertEquals(BsonArray(BsonAnyOf(BsonBoolean, BsonNull)), type)
+                    }
+                }
+            }
+        }
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.match(
+                    Criteria.where("released").is(true).andOperator(
+                        Criteria.where("hidden").is(false),
+                        Criteria.where("valid").is(true)
+                    )
+                )
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse a match stage provided with a Criteria (andOperator)`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        SpringCriteriaDialectParser.parse(query).assert(IsCommand.CommandType.AGGREGATE) {
+            component<HasSourceDialect> {
+                assertEquals(HasSourceDialect.DialectName.SPRING_CRITERIA, name)
+            }
+
+            collection<HasCollectionReference.OnlyCollection<PsiElement>> {
+                assertEquals("book", collection)
+            }
+
+            stageN(0, Name.MATCH) {
+                assertEquals(2, component<HasFilter<PsiElement>>()?.children?.size) {
+                    "Expected at-least 1 filter, found ${component<HasFilter<PsiElement>>()?.children?.size}"
+                }
+
+                filterN(0, Name.AND) {
+                    filterN(0, Name.EQ) {
+                        field<HasFieldReference.FromSchema<PsiElement>> {
+                            assertEquals("hidden", fieldName)
+                        }
+                        value<HasValueReference.Constant<PsiElement>> {
+                            assertEquals(BsonAnyOf(BsonNull, BsonBoolean), type)
+                            assertEquals(false, value)
+                        }
+                    }
+
+                    filterN(1, Name.EQ) {
+                        field<HasFieldReference.FromSchema<PsiElement>> {
+                            assertEquals("valid", fieldName)
+                        }
+                        value<HasValueReference.Constant<PsiElement>> {
+                            assertEquals(BsonAnyOf(BsonNull, BsonBoolean), type)
+                            assertEquals(true, value)
+                        }
+                    }
+                }
+
+                filterN(1, Name.EQ) {
+                    field<HasFieldReference.FromSchema<PsiElement>> {
+                        assertEquals("released", fieldName)
+                    }
+                    value<HasValueReference.Constant<PsiElement>> {
+                        assertEquals(BsonAnyOf(BsonNull, BsonBoolean), type)
+                        assertEquals(true, value)
+                    }
+                }
+            }
+        }
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.match(
+                    Criteria.where("released").is(true).orOperator(
+                        Criteria.where("hidden").is(false),
+                        Criteria.where("valid").is(true)
+                    )
+                )
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse a match stage provided with a Criteria (orOperator)`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        SpringCriteriaDialectParser.parse(query).assert(IsCommand.CommandType.AGGREGATE) {
+            component<HasSourceDialect> {
+                assertEquals(HasSourceDialect.DialectName.SPRING_CRITERIA, name)
+            }
+
+            collection<HasCollectionReference.OnlyCollection<PsiElement>> {
+                assertEquals("book", collection)
+            }
+
+            stageN(0, Name.MATCH) {
+                assertEquals(2, component<HasFilter<PsiElement>>()?.children?.size) {
+                    "Expected at-least 1 filter, found ${component<HasFilter<PsiElement>>()?.children?.size}"
+                }
+
+                filterN(0, Name.OR) {
+                    filterN(0, Name.EQ) {
+                        field<HasFieldReference.FromSchema<PsiElement>> {
+                            assertEquals("hidden", fieldName)
+                        }
+                        value<HasValueReference.Constant<PsiElement>> {
+                            assertEquals(BsonAnyOf(BsonNull, BsonBoolean), type)
+                            assertEquals(false, value)
+                        }
+                    }
+
+                    filterN(1, Name.EQ) {
+                        field<HasFieldReference.FromSchema<PsiElement>> {
+                            assertEquals("valid", fieldName)
+                        }
+                        value<HasValueReference.Constant<PsiElement>> {
+                            assertEquals(BsonAnyOf(BsonNull, BsonBoolean), type)
+                            assertEquals(true, value)
+                        }
+                    }
+                }
+
+                filterN(1, Name.EQ) {
+                    field<HasFieldReference.FromSchema<PsiElement>> {
+                        assertEquals("released", fieldName)
+                    }
+                    value<HasValueReference.Constant<PsiElement>> {
+                        assertEquals(BsonAnyOf(BsonNull, BsonBoolean), type)
+                        assertEquals(true, value)
+                    }
+                }
+            }
+        }
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.match(
+                    Criteria.where("released").is(true).norOperator(
+                        Criteria.where("hidden").is(false),
+                        Criteria.where("valid").is(true)
+                    )
+                )
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse a match stage provided with a Criteria (norOperator)`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        SpringCriteriaDialectParser.parse(query).assert(IsCommand.CommandType.AGGREGATE) {
+            component<HasSourceDialect> {
+                assertEquals(HasSourceDialect.DialectName.SPRING_CRITERIA, name)
+            }
+
+            collection<HasCollectionReference.OnlyCollection<PsiElement>> {
+                assertEquals("book", collection)
+            }
+
+            stageN(0, Name.MATCH) {
+                assertEquals(2, component<HasFilter<PsiElement>>()?.children?.size) {
+                    "Expected at-least 1 filter, found ${component<HasFilter<PsiElement>>()?.children?.size}"
+                }
+
+                filterN(0, Name.NOR) {
+                    filterN(0, Name.EQ) {
+                        field<HasFieldReference.FromSchema<PsiElement>> {
+                            assertEquals("hidden", fieldName)
+                        }
+                        value<HasValueReference.Constant<PsiElement>> {
+                            assertEquals(BsonAnyOf(BsonNull, BsonBoolean), type)
+                            assertEquals(false, value)
+                        }
+                    }
+
+                    filterN(1, Name.EQ) {
+                        field<HasFieldReference.FromSchema<PsiElement>> {
+                            assertEquals("valid", fieldName)
+                        }
+                        value<HasValueReference.Constant<PsiElement>> {
+                            assertEquals(BsonAnyOf(BsonNull, BsonBoolean), type)
+                            assertEquals(true, value)
+                        }
+                    }
+                }
+
+                filterN(1, Name.EQ) {
+                    field<HasFieldReference.FromSchema<PsiElement>> {
+                        assertEquals("released", fieldName)
+                    }
+                    value<HasValueReference.Constant<PsiElement>> {
+                        assertEquals(BsonAnyOf(BsonNull, BsonBoolean), type)
+                        assertEquals(true, value)
+                    }
+                }
+            }
+        }
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.match(
+                    Criteria.where("|";
+    }
+}
+        """
+    )
+    fun `should be able to determine a field reference in a match criteria`(psiFile: PsiFile) {
+        assertTrue(SpringCriteriaDialectParser.isReferenceToField(psiFile.caret()))
+    }
+}


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER-IF-ANY>

  eg. fix(type-hint): infer type of a constant for type checking INTELLIJ-1111
-->

## Description
Adds support for parsing, inspecting and autocompleting in an aggregation written using Spring Data MongoDB. The PR mainly focuses on parsing the common syntax for writing an aggregation, using `MongoTemplate.aggregate` and `MongoTemplate.aggregateStream` and a match stage written with [Aggregation.match](https://docs.spring.io/spring-data/mongodb/reference/api/java/org/springframework/data/mongodb/core/aggregation/Aggregation.html#match(org.springframework.data.mongodb.core.aggregation.AggregationExpression):~:text=1.10-,match,-public%20static%C2%A0).

<!--- Describe your changes in detail so reviewers have enough content on what this PR aims to achieve -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist

- [x] New tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
- [x] Changelog is updated accordingly.
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement).

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->