### PR TITLE
feat: add support for parsing, inspecting and autocompleting in a sort stage written using Spring Data MongoDB INTELLIJ-174

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ MongoDB plugin for IntelliJ IDEA.
 ## [Unreleased]
 
 ### Added
+* [INTELLIJ-174](https://jira.mongodb.org/browse/INTELLIJ-174) Add support for parsing, inspecting and autocompleting in a sort stage written using `Aggregation.sort` and chained `SortOperation`s using `and`. All the overloads of creating a `Sort` object are supported.
 * [INTELLIJ-187](https://jira.mongodb.org/browse/INTELLIJ-187) Use safe execution plans by default. Allow full execution
   plans through a Plugin settings flag.
 * [INTELLIJ-180](https://jira.mongodb.org/browse/INTELLIJ-180) Telemetry when inspections are shown and resolved.

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/SpringCriteriaCompletionContributorTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/SpringCriteriaCompletionContributorTest.kt
@@ -984,4 +984,551 @@ class Repository {
             },
         )
     }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.sort(Sort.Direction.ASC, "<caret>")
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Aggregation#sort call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.sort(
+                    Sort.by("<caret>")
+                )
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Sort#by of Aggregation#sort call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.sort(
+                    Sort.by(Sort.Direction.ASC, "<caret>")
+                )
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Sort#by with direction of Aggregation#sort call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.sort(
+                    Sort.by(
+                        Sort.Order.asc("<caret>")
+                    )
+                )
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Order#asc of Aggregation#sort call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.sort(
+                    Sort.by(
+                        Sort.Order.desc("<caret>")
+                    )
+                )
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Order#desc of Aggregation#sort call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.sort(
+                    Sort.by(
+                        Sort.Order.by("<caret>")
+                    )
+                )
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Order#by of Aggregation#sort call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.sort(
+                    Sort.by(
+                        List.of(
+                            Sort.Order.by("<caret>")
+                        )
+                    )
+                )
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in List of Order of Aggregation#sort call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
 }

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/SpringCriteriaMongoDbAutocompletionPopupHandlerTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/SpringCriteriaMongoDbAutocompletionPopupHandlerTest.kt
@@ -924,4 +924,558 @@ class Repository {
             },
         )
     }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.sort(Sort.Direction.ASC, <caret>)
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Aggregation#sort call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        fixture.type('"')
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.sort(
+                    Sort.by(<caret>)
+                )
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Sort#by of Aggregation#sort call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        fixture.type('"')
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.sort(
+                    Sort.by(Sort.Direction.ASC, <caret>)
+                )
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Sort#by with direction of Aggregation#sort call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        fixture.type('"')
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.sort(
+                    Sort.by(
+                        Sort.Order.asc(<caret>)
+                    )
+                )
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Order#asc of Aggregation#sort call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        fixture.type('"')
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.sort(
+                    Sort.by(
+                        Sort.Order.desc(<caret>)
+                    )
+                )
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Order#desc of Aggregation#sort call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        fixture.type('"')
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.sort(
+                    Sort.by(
+                        Sort.Order.by(<caret>)
+                    )
+                )
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Order#by of Aggregation#sort call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        fixture.type('"')
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.sort(
+                    Sort.by(
+                        List.of(
+                            Sort.Order.by(<caret>)
+                        )
+                    )
+                )
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in List of Order of Aggregation#sort call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        fixture.type('"')
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
 }

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/impl/SpringCriteriaFieldCheckLinterInspectionTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/impl/SpringCriteriaFieldCheckLinterInspectionTest.kt
@@ -166,10 +166,12 @@ class BookRepository {
     @ParsingTest(
         fileName = "Repository.java",
         value = """
+import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.util.List;
 import static org.springframework.data.mongodb.core.query.Query.query;
 import static org.springframework.data.mongodb.core.query.Criteria.where;
 
@@ -216,6 +218,58 @@ class BookRepository {
                 ),
                 Aggregation.unwind(
                     <warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">"released"</warning>
+                ),
+                Aggregation.sort(
+                    Sort.Direction.ASC,
+                    <warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">"released"</warning>,
+                    <warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedAsVariable</warning>,
+                    <warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedFromMethodCall()</warning>
+                ).and(
+                    Sort.Direction.ASC,
+                    <warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedAsVariable</warning>
+                ).and(
+                    Sort.Direction.ASC,
+                    <warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedFromMethodCall()</warning>
+                ),
+                Aggregation.sort(
+                    Sort.by(
+                        <warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">"released"</warning>,
+                        <warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedAsVariable</warning>,
+                        <warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedFromMethodCall()</warning>
+                    ).and(
+                        Sort.by(
+                            Sort.Direction.ASC,
+                            <warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">"released"</warning>,
+                            <warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedAsVariable</warning>,
+                            <warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedFromMethodCall()</warning>
+                        ).reverse()
+                    ).and(
+                        Sort.by(
+                            Sort.Order.asc(
+                                <warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">"released"</warning>
+                            ),
+                            Sort.Order.desc(
+                                <warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedAsVariable</warning>
+                            ),
+                            Sort.Order.by(
+                                <warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedFromMethodCall()</warning>
+                            )
+                        ).ascending()
+                    ).and(
+                        Sort.by(
+                            List.of(
+                                Sort.Order.asc(
+                                    <warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">"released"</warning>
+                                ),
+                                Sort.Order.desc(
+                                    <warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedAsVariable</warning>
+                                ),
+                                Sort.Order.by(
+                                    <warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedFromMethodCall()</warning>
+                                )
+                            )
+                        ).descending()
+                    )
                 )
             ),
             Book.class,

--- a/packages/jetbrains-plugin/src/test/resources/project-fixtures/basic-java-project-with-mongodb/src/main/java/alt/mongodb/springcriteria/SpringCriteriaRepository.java
+++ b/packages/jetbrains-plugin/src/test/resources/project-fixtures/basic-java-project-with-mongodb/src/main/java/alt/mongodb/springcriteria/SpringCriteriaRepository.java
@@ -1,5 +1,6 @@
 package alt.mongodb.springcriteria;
 
+import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.Fields;
@@ -35,7 +36,12 @@ public class SpringCriteriaRepository {
         return template.aggregate(
             Aggregation.newAggregation(
                 Aggregation.match(where( "tomatoes.viewer.rating").gte(rating)),
-                Aggregation.project("fieldA").andInclude("fieldB").andExclude("fieldC")
+                Aggregation.project("fieldA").andInclude("fieldB").andExclude("fieldC"),
+                Aggregation.sort(Sort.Direction.ASC, "asd"),
+                Aggregation.sort(Sort.by("rated", "qwe")),
+                Aggregation.sort(Sort.by(Sort.Direction.ASC, "rates")),
+                Aggregation.sort(Sort.by(Sort.Order.by("rated"), Sort.Order.by("ratedd"))),
+                Aggregation.sort(Sort.by(List.of(Sort.Order.by("rated"), Sort.Order.by("rateds"))))
             ),
             Movie.class,
             Movie.class

--- a/packages/mongodb-dialects/spring-criteria/src/main/kotlin/com/mongodb/jbplugin/dialects/springcriteria/SpringCriteriaDialectParser.kt
+++ b/packages/mongodb-dialects/spring-criteria/src/main/kotlin/com/mongodb/jbplugin/dialects/springcriteria/SpringCriteriaDialectParser.kt
@@ -12,6 +12,7 @@ import com.mongodb.jbplugin.dialects.springcriteria.QueryTargetCollectionExtract
 import com.mongodb.jbplugin.dialects.springcriteria.QueryTargetCollectionExtractor.or
 import com.mongodb.jbplugin.dialects.springcriteria.aggregationstageparsers.MatchStageParser
 import com.mongodb.jbplugin.dialects.springcriteria.aggregationstageparsers.ProjectStageParser
+import com.mongodb.jbplugin.dialects.springcriteria.aggregationstageparsers.SortStageParser
 import com.mongodb.jbplugin.dialects.springcriteria.aggregationstageparsers.StageParser
 import com.mongodb.jbplugin.dialects.springcriteria.aggregationstageparsers.UnwindStageParser
 import com.mongodb.jbplugin.mql.BsonAny
@@ -31,7 +32,8 @@ object SpringCriteriaDialectParser : DialectParser<PsiElement> {
     private val aggregationStageParsers: List<StageParser> = listOf(
         MatchStageParser(::parseFilterRecursively),
         ProjectStageParser(),
-        UnwindStageParser()
+        UnwindStageParser(),
+        SortStageParser()
     )
 
     override fun isCandidateForQuery(source: PsiElement) =

--- a/packages/mongodb-dialects/spring-criteria/src/main/kotlin/com/mongodb/jbplugin/dialects/springcriteria/aggregationstageparsers/ProjectStageParser.kt
+++ b/packages/mongodb-dialects/spring-criteria/src/main/kotlin/com/mongodb/jbplugin/dialects/springcriteria/aggregationstageparsers/ProjectStageParser.kt
@@ -225,7 +225,7 @@ class ProjectStageParser : StageParser {
 }
 
 /**
- * From a PsiMethodCallExpression, it attempts to travel upwards the chain(assuming there is one)
+ * From a PsiMethodCallExpression, it attempts to travel backwards the chain(assuming there is one)
  * while gathering other PsiMethodCallExpressions it comes across, until there is no further
  * PsiMethodCallExpression in the chain. For example, consider the following method call
  * ```
@@ -238,6 +238,9 @@ class ProjectStageParser : StageParser {
  *   Aggregation.project().andInclude("fieldA")
  *   Aggregation.project()
  * ]
+ *
+ * Note: The collected chain of method calls always starts from the method call all the way to the
+ * right of the chain and ends with the root method call.
  */
 fun PsiMethodCallExpression.gatherChainedCalls(): List<PsiMethodCallExpression> {
     val chain = mutableListOf<PsiMethodCallExpression>()

--- a/packages/mongodb-dialects/spring-criteria/src/main/kotlin/com/mongodb/jbplugin/dialects/springcriteria/aggregationstageparsers/SortStageParser.kt
+++ b/packages/mongodb-dialects/spring-criteria/src/main/kotlin/com/mongodb/jbplugin/dialects/springcriteria/aggregationstageparsers/SortStageParser.kt
@@ -1,0 +1,393 @@
+package com.mongodb.jbplugin.dialects.springcriteria.aggregationstageparsers
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiEnumConstant
+import com.intellij.psi.PsiExpression
+import com.intellij.psi.PsiField
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiMethodCallExpression
+import com.mongodb.jbplugin.dialects.javadriver.glossary.fuzzyResolveMethod
+import com.mongodb.jbplugin.dialects.javadriver.glossary.getVarArgsOrIterableArgs
+import com.mongodb.jbplugin.dialects.javadriver.glossary.resolveElementUntil
+import com.mongodb.jbplugin.dialects.javadriver.glossary.resolveFieldNameFromExpression
+import com.mongodb.jbplugin.dialects.javadriver.glossary.resolveToIterableCallExpression
+import com.mongodb.jbplugin.dialects.javadriver.glossary.resolveToMethodCallExpression
+import com.mongodb.jbplugin.dialects.springcriteria.AGGREGATE_FQN
+import com.mongodb.jbplugin.mql.BsonInt32
+import com.mongodb.jbplugin.mql.Node
+import com.mongodb.jbplugin.mql.components.HasFieldReference
+import com.mongodb.jbplugin.mql.components.HasSorts
+import com.mongodb.jbplugin.mql.components.HasValueReference
+import com.mongodb.jbplugin.mql.components.Name
+import com.mongodb.jbplugin.mql.components.Named
+
+internal const val SORT_OPERATION_FQN = "org.springframework.data.mongodb.core.aggregation.SortOperation"
+internal const val SORT_FQN = "org.springframework.data.domain.Sort"
+internal const val DIRECTION_FQN = "org.springframework.data.domain.Sort.Direction"
+internal const val ORDER_FQN = "org.springframework.data.domain.Sort.Order"
+
+class SortStageParser : StageParser {
+    override fun isSuitableForFieldAutoComplete(
+        methodCall: PsiMethodCallExpression,
+        method: PsiMethod
+    ): Boolean = canParse(method)
+
+    override fun canParse(stageCallMethod: PsiMethod): Boolean {
+        val methodFqn = stageCallMethod.containingClass?.qualifiedName ?: return false
+        return listOf(AGGREGATE_FQN, SORT_OPERATION_FQN).contains(methodFqn) &&
+            // we consider the root call sort and any chained calls which we currently
+            // support
+            listOf("sort", "and").contains(stageCallMethod.name)
+    }
+
+    override fun parse(stageCall: PsiMethodCallExpression): Node<PsiElement> {
+        return createSortNode(
+            source = stageCall,
+            criteria = stageCall.gatherChainedCalls().flatMap { methodCall ->
+                val method = methodCall.fuzzyResolveMethod() ?: return@flatMap emptyList()
+                when (method.name) {
+                    "sort", "and" -> parseSortOrAndCall(methodCall)
+                    else -> emptyList()
+                }
+            }
+        )
+    }
+
+    /**
+     * Parses a `Aggregation.sort` or `SortOperation.and` call and returns a list of MQL Node
+     * representing sort criteria. Both methods has two overloads both which we support:
+     * 1. `Aggregation.sort(Sort sort)`
+     * 2. `Aggregation.sort(Direction direction, String... fields)`
+     * 3. `SortOperation.and(Sort sort)`
+     * 4. `SortOperation.sort(Direction direction, String... fields)`
+     */
+    private fun parseSortOrAndCall(methodCall: PsiMethodCallExpression): List<Node<PsiElement>> {
+        val firstArgumentExpression = methodCall.argumentList.expressions.getOrNull(0)
+            ?: return emptyList()
+
+        return if (firstArgumentExpression.isDirectionEnum()) {
+            parseDirectionArgumentAndFieldsToSortCriteria(
+                directionArgumentExpression = firstArgumentExpression,
+                fieldArgumentExpressions = methodCall.argumentList.expressions.drop(1),
+                directionForcedFromParentChain = null,
+                reverseCountForcedFromParentChain = 0
+            )
+        } else if (firstArgumentExpression.isSortObject()) {
+            parseSortObjectArgument(
+                firstArgumentExpression.resolveToSortCreationCall()!!,
+                null,
+                0
+            )
+        } else {
+            emptyList()
+        }
+    }
+
+    private fun parseDirectionArgumentAndFieldsToSortCriteria(
+        directionArgumentExpression: PsiExpression,
+        fieldArgumentExpressions: List<PsiExpression>,
+        directionForcedFromParentChain: Name?,
+        reverseCountForcedFromParentChain: Int
+    ): List<Node<PsiElement>> {
+        val directionName = directionArgumentExpression.resolveToDirectionName().derivedDirection(
+            directionForcedFromParentChain,
+            reverseCountForcedFromParentChain
+        )
+        return fieldArgumentExpressions.map { fieldExpression ->
+            createSortCriteria(
+                directionName = directionName,
+                fieldExpression = fieldExpression,
+                directionExpression = directionArgumentExpression
+            )
+        }
+    }
+
+    private fun parseSortObjectArgument(
+        sortCreationMethodCall: PsiMethodCallExpression,
+        directionForcedFromParentChain: Name?,
+        reverseCountForcedFromParentChain: Int,
+    ): List<Node<PsiElement>> {
+        var forcedDirection = directionForcedFromParentChain
+        var reverseCount = reverseCountForcedFromParentChain
+        return sortCreationMethodCall.gatherChainedCalls().flatMapIndexed { index, methodCall ->
+            val method = methodCall.fuzzyResolveMethod()
+
+            if (method?.containingClass?.qualifiedName != SORT_FQN) {
+                return@flatMapIndexed emptyList<Node<PsiElement>>()
+            }
+
+            if (method.name == "ascending" || method.name == "descending") {
+                // If we have ascending as the last chained call and there was no other forced
+                // direction from parent chain then the entire chain is forced to have the current
+                // order
+                if (index == 0 && forcedDirection == null) {
+                    forcedDirection = if (method.name == "ascending") {
+                        Name.ASCENDING
+                    } else {
+                        Name.DESCENDING
+                    }
+                }
+                // The current order could also come before a reverse, in this chain or from a parent
+                // chain. In that case, we revert the forced direction as many times as we encountered
+                // reverse and that becomes the new forced direction for this chain
+                else if (index != 0 && forcedDirection == null) {
+                    val supposedNewDirection = if (method.name == "ascending") {
+                        Name.ASCENDING
+                    } else {
+                        Name.DESCENDING
+                    }
+                    forcedDirection = supposedNewDirection.derivedDirection(
+                        directionForcedFromParentChain = null,
+                        reverseCountForcedFromParentChain = reverseCount
+                    )
+                    reverseCount = 0
+                }
+                return@flatMapIndexed emptyList<Node<PsiElement>>()
+            }
+            // Accounting for reverse only makes sense when there is no direction forced already
+            // either from the current chain or from parent chain
+            else if (method.name == "reverse" && forcedDirection == null) {
+                reverseCount += 1
+                return@flatMapIndexed emptyList<Node<PsiElement>>()
+            }
+            // This is how we chain additional Sort criteria chains onto the current chain.
+            // This chained Sort criteria will inherit the forcedDirection and reverseCount from
+            // the current chain
+            else if (method.name == "and") {
+                val firstArgumentExpression = methodCall.argumentList.expressions.getOrNull(0)
+                val sortCreationMethodCallPassedToAnd =
+                    firstArgumentExpression?.resolveToSortCreationCall()
+                        ?: return@flatMapIndexed emptyList<Node<PsiElement>>()
+
+                return@flatMapIndexed parseSortObjectArgument(
+                    sortCreationMethodCallPassedToAnd,
+                    forcedDirection,
+                    reverseCount
+                )
+            } else if (method.name == "by") {
+                return@flatMapIndexed parseSortByMethodCall(
+                    methodCall = methodCall,
+                    directionForcedFromParentChain = forcedDirection,
+                    reverseCountForcedFromParentChain = reverseCount
+                )
+            } else {
+                return@flatMapIndexed emptyList<Node<PsiElement>>()
+            }
+        }
+    }
+
+    private fun parseSortByMethodCall(
+        methodCall: PsiMethodCallExpression,
+        directionForcedFromParentChain: Name?,
+        reverseCountForcedFromParentChain: Int
+    ): List<Node<PsiElement>> {
+        val firstArgumentExpression = methodCall.argumentList.expressions.getOrNull(0)
+            ?: return emptyList()
+
+        return if (firstArgumentExpression.isDirectionEnum()) {
+            parseDirectionArgumentAndFieldsToSortCriteria(
+                // Kinda ambiguous if the direction was forced from parent chain
+                directionArgumentExpression = firstArgumentExpression,
+                fieldArgumentExpressions = methodCall.argumentList.expressions.drop(1),
+                directionForcedFromParentChain = directionForcedFromParentChain,
+                reverseCountForcedFromParentChain = reverseCountForcedFromParentChain
+            )
+        } else if (firstArgumentExpression.isOrderObject() ||
+            firstArgumentExpression.isParseableJavaIterable()
+        ) {
+            parseOrderObjects(
+                methodCall.getVarArgsOrIterableArgs(),
+                directionForcedFromParentChain,
+                reverseCountForcedFromParentChain
+            )
+        } else {
+            methodCall.argumentList.expressions.map { fieldExpression ->
+                createSortCriteria(
+                    directionName = Name.ASCENDING.derivedDirection(
+                        directionForcedFromParentChain,
+                        reverseCountForcedFromParentChain
+                    ),
+                    fieldExpression = fieldExpression,
+                    directionExpression = methodCall
+                )
+            }
+        }
+    }
+
+    private fun parseOrderObjects(
+        orderObjectsExpression: List<PsiExpression>,
+        directionForcedFromParentChain: Name?,
+        reverseCountForcedFromParentChain: Int
+    ): List<Node<PsiElement>> {
+        return orderObjectsExpression.mapNotNull { orderExpression ->
+            val orderCreationCall = orderExpression.resolveToOrderCreationCall()
+            val orderCreationMethod =
+                orderCreationCall?.fuzzyResolveMethod() ?: return@mapNotNull null
+            val fieldArgumentExpression = orderCreationCall.argumentList.expressions.getOrNull(0)
+                ?: return@mapNotNull null
+            val supposedDirectionForThisOrder = when (orderCreationMethod.name) {
+                "asc", "by" -> Name.ASCENDING
+                "desc" -> Name.DESCENDING
+                else -> Name.UNKNOWN
+            }
+            val finalDirectionForThisOrder = supposedDirectionForThisOrder.derivedDirection(
+                directionForcedFromParentChain,
+                reverseCountForcedFromParentChain
+            )
+
+            createSortCriteria(
+                directionName = finalDirectionForThisOrder,
+                fieldExpression = fieldArgumentExpression,
+                directionExpression = orderExpression
+            )
+        }
+    }
+
+    private fun createSortCriteria(
+        directionName: Name,
+        fieldExpression: PsiExpression,
+        directionExpression: PsiElement,
+    ): Node<PsiElement> {
+        val fieldReference = fieldExpression.resolveFieldNameFromExpression()
+        return Node(
+            source = fieldExpression,
+            components = listOf(
+                Named(directionName),
+                HasFieldReference(fieldReference),
+                HasValueReference(
+                    reference = when (directionName) {
+                        Name.ASCENDING,
+                        Name.DESCENDING -> HasValueReference.Inferred(
+                            source = directionExpression,
+                            type = BsonInt32,
+                            value = if (directionName == Name.ASCENDING) 1 else -1
+                        )
+                        else -> HasValueReference.Unknown
+                    }
+                )
+            )
+        )
+    }
+
+    private fun createSortNode(
+        source: PsiMethodCallExpression,
+        criteria: List<Node<PsiElement>>
+    ): Node<PsiElement> {
+        return Node(
+            source = source,
+            components = listOf(
+                Named(Name.SORT),
+                HasSorts(criteria)
+            )
+        )
+    }
+}
+
+/**
+ * Checks if the PsiExpression represents a Sort object
+ */
+fun PsiExpression.isSortObject(): Boolean {
+    return resolveToSortCreationCall() != null
+}
+
+/**
+ * Checks if the PsiExpression represents a Direction enum
+ */
+fun PsiExpression.isDirectionEnum(): Boolean {
+    return resolveToDirectionEnum() != null
+}
+
+/**
+ * Checks if the PsiExpression represents an Order object
+ */
+fun PsiExpression.isOrderObject(): Boolean {
+    return resolveToOrderCreationCall() != null
+}
+
+/**
+ * Checks if the PsiExpression is a parseable Java iterable
+ */
+fun PsiExpression.isParseableJavaIterable(): Boolean {
+    return resolveToIterableCallExpression() != null
+}
+
+/**
+ * Resolves a PsiExpression to a PsiMethodCallExpression that creates a Sort object.
+ * A Sort object is generally created using static methods available on the Sort class. The most
+ * common of those being `Sort.by` and different overloads of it.
+ */
+fun PsiExpression.resolveToSortCreationCall(): PsiMethodCallExpression? {
+    return resolveToMethodCallExpression { _, method ->
+        method.containingClass?.qualifiedName == SORT_FQN &&
+            listOf(
+                "ascending",
+                "descending",
+                "reverse",
+                "and",
+                "by"
+            ).contains(method.name)
+    }
+}
+
+/**
+ * Resolves a PsiExpression to a PsiEnumConstant that represents a Direction enum
+ */
+fun PsiExpression.resolveToDirectionEnum(): PsiEnumConstant? {
+    return resolveElementUntil { element ->
+        when (element) {
+            is PsiEnumConstant -> element.containingClass?.qualifiedName == DIRECTION_FQN
+            is PsiField -> element.type.equalsToText(DIRECTION_FQN)
+            else -> false
+        }
+    }
+}
+
+/**
+ * Helper to resolve a Name from PsiExpression that is points to a Direction enum
+ */
+fun PsiExpression.resolveToDirectionName(): Name {
+    val resolvedDirectionEnum = resolveToDirectionEnum()
+    return when (resolvedDirectionEnum?.name) {
+        "ASC" -> Name.ASCENDING
+        "DESC" -> Name.DESCENDING
+        else -> Name.UNKNOWN
+    }
+}
+
+/**
+ * Resolves a PsiMethodCallExpression that is responsible for creating the Order object represented
+ * by the referenced PsiExpression
+ */
+fun PsiExpression.resolveToOrderCreationCall(): PsiMethodCallExpression? {
+    return resolveToMethodCallExpression { _, method ->
+        method.containingClass?.qualifiedName == ORDER_FQN &&
+            listOf(
+                "asc",
+                "desc",
+                "by"
+            ).contains(method.name)
+    }
+}
+
+/**
+ * Helper to derive a Direction when there is a forced direction or reversal applied from the
+ * earlier / parent chains
+ */
+fun Name.derivedDirection(
+    directionForcedFromParentChain: Name?,
+    reverseCountForcedFromParentChain: Int
+): Name {
+    if (directionForcedFromParentChain != null) {
+        return directionForcedFromParentChain
+    }
+
+    var derivedDirection = this
+    for (count in 0..<reverseCountForcedFromParentChain) {
+        derivedDirection = when (derivedDirection) {
+            Name.ASCENDING -> Name.DESCENDING
+            Name.DESCENDING -> Name.ASCENDING
+            else -> return Name.UNKNOWN
+        }
+    }
+    return derivedDirection
+}

--- a/packages/mongodb-dialects/spring-criteria/src/main/kotlin/com/mongodb/jbplugin/dialects/springcriteria/aggregationstageparsers/SortStageParser.kt
+++ b/packages/mongodb-dialects/spring-criteria/src/main/kotlin/com/mongodb/jbplugin/dialects/springcriteria/aggregationstageparsers/SortStageParser.kt
@@ -30,7 +30,12 @@ class SortStageParser : StageParser {
     override fun isSuitableForFieldAutoComplete(
         methodCall: PsiMethodCallExpression,
         method: PsiMethod
-    ): Boolean = canParse(method)
+    ): Boolean {
+        val isInStageCreationCall = canParse(method)
+        return isInStageCreationCall ||
+            method.isSortCreationMethod() ||
+            method.isOrderCreationMethod()
+    }
 
     override fun canParse(stageCallMethod: PsiMethod): Boolean {
         val methodFqn = stageCallMethod.containingClass?.qualifiedName ?: return false
@@ -318,15 +323,19 @@ fun PsiExpression.isParseableJavaIterable(): Boolean {
  */
 fun PsiExpression.resolveToSortCreationCall(): PsiMethodCallExpression? {
     return resolveToMethodCallExpression { _, method ->
-        method.containingClass?.qualifiedName == SORT_FQN &&
-            listOf(
-                "ascending",
-                "descending",
-                "reverse",
-                "and",
-                "by"
-            ).contains(method.name)
+        method.isSortCreationMethod()
     }
+}
+
+fun PsiMethod.isSortCreationMethod(): Boolean {
+    return containingClass?.qualifiedName == SORT_FQN &&
+        listOf(
+            "ascending",
+            "descending",
+            "reverse",
+            "and",
+            "by"
+        ).contains(name)
 }
 
 /**
@@ -360,13 +369,17 @@ fun PsiExpression.resolveToDirectionName(): Name {
  */
 fun PsiExpression.resolveToOrderCreationCall(): PsiMethodCallExpression? {
     return resolveToMethodCallExpression { _, method ->
-        method.containingClass?.qualifiedName == ORDER_FQN &&
-            listOf(
-                "asc",
-                "desc",
-                "by"
-            ).contains(method.name)
+        method.isOrderCreationMethod()
     }
+}
+
+fun PsiMethod.isOrderCreationMethod(): Boolean {
+    return containingClass?.qualifiedName == ORDER_FQN &&
+        listOf(
+            "asc",
+            "desc",
+            "by"
+        ).contains(name)
 }
 
 /**

--- a/packages/mongodb-dialects/spring-criteria/src/test/kotlin/com/mongodb/jbplugin/dialects/springcriteria/IntegrationTest.kt
+++ b/packages/mongodb-dialects/spring-criteria/src/test/kotlin/com/mongodb/jbplugin/dialects/springcriteria/IntegrationTest.kt
@@ -40,6 +40,7 @@ import com.mongodb.jbplugin.mql.components.HasCollectionReference
 import com.mongodb.jbplugin.mql.components.HasFieldReference
 import com.mongodb.jbplugin.mql.components.HasFilter
 import com.mongodb.jbplugin.mql.components.HasProjections
+import com.mongodb.jbplugin.mql.components.HasSorts
 import com.mongodb.jbplugin.mql.components.HasUpdates
 import com.mongodb.jbplugin.mql.components.HasValueReference
 import com.mongodb.jbplugin.mql.components.IsCommand
@@ -319,10 +320,10 @@ fun Node<PsiElement>.stageN(
     if (name != null) {
         val stageName = stage!!.component<Named>()
         assertNotEquals(null, stageName) {
-            "Expected a stage with name $name but null found."
+            "Expected a stage with name $name but null found at index $n."
         }
         assertEquals(name, stageName!!.name) {
-            "Expected a stage with name $name but ${stageName.name} found."
+            "Expected a stage with name $name but ${stageName.name} found at index $n."
         }
     }
 
@@ -375,6 +376,31 @@ fun Node<PsiElement>.projectionN(
     }
 
     projection.assertions()
+}
+
+fun Node<PsiElement>.sortN(
+    n: Int,
+    name: Name? = null,
+    stageIndex: Int? = null,
+    assertions: Node<PsiElement>.() -> Unit = {
+    },
+) {
+    val sorts = component<HasSorts<PsiElement>>()
+    assertNotNull(sorts)
+
+    val sort = sorts!!.children[n]
+
+    if (name != null) {
+        val qname = sort.component<Named>()
+        assertNotEquals(null, qname) {
+            "StageIndex: $stageIndex, SortCriteriaIndex: $n :: Expected a named operation with name $name but null found."
+        }
+        assertEquals(name, qname?.name) {
+            "StageIndex: $stageIndex, SortCriteriaIndex: $n :: Expected a named operation with name $name but $qname found."
+        }
+    }
+
+    sort.assertions()
 }
 
 fun Node<PsiElement>.updateN(

--- a/packages/mongodb-dialects/spring-criteria/src/test/kotlin/com/mongodb/jbplugin/dialects/springcriteria/aggregationstageparsers/SortStageParserTest.kt
+++ b/packages/mongodb-dialects/spring-criteria/src/test/kotlin/com/mongodb/jbplugin/dialects/springcriteria/aggregationstageparsers/SortStageParserTest.kt
@@ -1,0 +1,737 @@
+package com.mongodb.jbplugin.dialects.springcriteria.aggregationstageparsers
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiExpression
+import com.intellij.psi.PsiFile
+import com.mongodb.jbplugin.dialects.springcriteria.IntegrationTest
+import com.mongodb.jbplugin.dialects.springcriteria.ParsingTest
+import com.mongodb.jbplugin.dialects.springcriteria.SpringCriteriaDialectParser
+import com.mongodb.jbplugin.dialects.springcriteria.assert
+import com.mongodb.jbplugin.dialects.springcriteria.collection
+import com.mongodb.jbplugin.dialects.springcriteria.component
+import com.mongodb.jbplugin.dialects.springcriteria.field
+import com.mongodb.jbplugin.dialects.springcriteria.getQueryAtMethod
+import com.mongodb.jbplugin.dialects.springcriteria.sortN
+import com.mongodb.jbplugin.dialects.springcriteria.stageN
+import com.mongodb.jbplugin.dialects.springcriteria.value
+import com.mongodb.jbplugin.mql.BsonInt32
+import com.mongodb.jbplugin.mql.components.HasAggregation
+import com.mongodb.jbplugin.mql.components.HasCollectionReference
+import com.mongodb.jbplugin.mql.components.HasFieldReference
+import com.mongodb.jbplugin.mql.components.HasSorts
+import com.mongodb.jbplugin.mql.components.HasSourceDialect
+import com.mongodb.jbplugin.mql.components.HasValueReference
+import com.mongodb.jbplugin.mql.components.IsCommand
+import com.mongodb.jbplugin.mql.components.Name
+import org.junit.jupiter.api.Assertions.assertEquals
+
+@IntegrationTest
+class SortStageParserTest {
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    SortOperation sortFromMethodCall() {
+        return Aggregation.sort();
+    }
+    
+    SortOperation sortChainFromMethodCall() {
+        return Aggregation.sort().and();
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        SortOperation sortAsVariable = Aggregation.sort();
+        SortOperation sortChainAsVariable = Aggregation.sort().and();
+        return template.aggregate(
+            Aggregation.newAggregation(
+                // Simple sort stage referenced differently
+                Aggregation.sort(),
+                sortAsVariable,
+                sortFromMethodCall(),
+
+                // Sort stage chained with a supported method
+                Aggregation.sort().and(),
+                sortChainAsVariable,
+                sortChainFromMethodCall()
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse empty sort stages and its variants`(psiFile: PsiFile) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        parseAndAssertForSortStages(
+            query = query,
+            expectedSortStagesCounts = 6,
+            sortStagesExpectations = listOf(
+                0 to listOf(),
+                0 to listOf(),
+                0 to listOf(),
+                0 to listOf(),
+                0 to listOf(),
+                0 to listOf(),
+            )
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.SortOperation;import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    String field2() {
+        return "field2";
+    }
+    
+    SortOperation getSortNoFields() {
+        return Aggregation.sort(Sort.Direction.ASC);
+    }
+    
+    SortOperation getSortNoFieldsChained() {
+        return Aggregation.sort(Sort.Direction.DESC).and(Sort.Direction.ASC);
+    }
+    
+    SortOperation getSortWithFields() {
+        String field1 = "field1";
+        return Aggregation.sort(Sort.Direction.ASC, "field0", field1, field2());
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        String field1 = "field1";
+        SortOperation sortNoFields = Aggregation.sort(Sort.Direction.ASC);
+        SortOperation sortNoFieldsChained = Aggregation.sort(Sort.Direction.DESC).and(Sort.Direction.ASC);
+        
+        SortOperation sortWithFields = Aggregation.sort(Sort.Direction.DESC, "field0", field1, field2());
+        return template.aggregate(
+            Aggregation.newAggregation(
+                // The direction variants but without specifying fields
+                // Should result in no sort criteria
+                Aggregation.sort(Sort.Direction.ASC),
+                sortNoFields,
+                getSortNoFields(),
+                Aggregation.sort(Sort.Direction.DESC).and(Sort.Direction.ASC).and(Sort.Direction.DESC),
+                sortNoFieldsChained,
+                getSortNoFieldsChained(),
+
+                // The direction variants of .sort call with fields
+                Aggregation.sort(Sort.Direction.ASC, "field0", field1, field2()),
+                sortWithFields,
+                getSortWithFields(),
+                Aggregation.sort(Sort.Direction.ASC, "field0").and(Sort.Direction.DESC, field1).and(Sort.Direction.ASC, field2())
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse sort method call accepting Direction enum and field names, supported chained calls and their variants`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        parseAndAssertForSortStages(
+            query = query,
+            expectedSortStagesCounts = 10,
+            sortStagesExpectations = listOf(
+                // Expectations for the direction variants but without specifying fields
+                0 to listOf(),
+                0 to listOf(),
+                0 to listOf(),
+                0 to listOf(),
+                0 to listOf(),
+                0 to listOf(),
+
+                // Expectations for direction variants of .sort call with fields
+                3 to listOf(
+                    Triple("field0", Name.ASCENDING, 1),
+                    Triple("field1", Name.ASCENDING, 1),
+                    Triple("field2", Name.ASCENDING, 1),
+                ),
+                3 to listOf(
+                    Triple("field0", Name.DESCENDING, -1),
+                    Triple("field1", Name.DESCENDING, -1),
+                    Triple("field2", Name.DESCENDING, -1),
+                ),
+                3 to listOf(
+                    Triple("field0", Name.ASCENDING, 1),
+                    Triple("field1", Name.ASCENDING, 1),
+                    Triple("field2", Name.ASCENDING, 1),
+                ),
+                3 to listOf(
+                    Triple("field2", Name.ASCENDING, 1),
+                    Triple("field1", Name.DESCENDING, -1),
+                    Triple("field0", Name.ASCENDING, 1),
+                )
+            )
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.domain.Sort;import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    String getField2() {
+        return "field2";
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        String field1 = "field1";
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.sort(
+                    Sort.by(
+                        Sort.Order.asc("field0"), // ascending
+                        Sort.Order.desc(field1), // descending
+                        Sort.Order.by(getField2()) // default ascending
+                    )
+                ),
+                Aggregation.sort(
+                    Sort.by(
+                        List.of(
+                            Sort.Order.asc("field0"), // ascending
+                            Sort.Order.desc(field1), // descending
+                            Sort.Order.by(getField2()) // default ascending
+                        )
+                    )
+                )
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse sort call provided with an Order object of List of Order objects`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        parseAndAssertForSortStages(
+            query = query,
+            expectedSortStagesCounts = 2,
+            sortStagesExpectations = listOf(
+                3 to listOf(
+                    Triple("field0", Name.ASCENDING, 1),
+                    Triple("field1", Name.DESCENDING, -1),
+                    Triple("field2", Name.ASCENDING, 1),
+                ),
+                3 to listOf(
+                    Triple("field0", Name.ASCENDING, 1),
+                    Triple("field1", Name.DESCENDING, -1),
+                    Triple("field2", Name.ASCENDING, 1),
+                ),
+            )
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.domain.Sort;import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    String getField2() {
+        return "field2";
+    }
+    
+    Sort getSortWithoutDirection() {
+        String field1 = "field1";
+        return Sort.by("field0", field1, getField2());
+    }
+    
+    Sort getSortWithDirection() {
+        String field1 = "field1";
+        return Sort.by(Sort.Direction.DESC, "field0", field1, getField2());
+    }
+    
+    Sort getSecondChainedSort() {
+        return Sort.by(getField2());
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        String field1 = "field1";
+        Sort sortWithoutDirection = Sort.by("field0", field1, getField2());
+        Sort sortWithDirection = Sort.by(Sort.Direction.DESC, "field0", field1, getField2());
+        
+        Sort firstChainedSort = Sort.by(Sort.Direction.DESC, field1);
+        return template.aggregate(
+            Aggregation.newAggregation(
+                // .sort calls with Sort object
+                Aggregation.sort(Sort.by("field0", field1, getField2())),
+                Aggregation.sort(sortWithoutDirection),
+                Aggregation.sort(getSortWithoutDirection()),
+                Aggregation.sort(Sort.by(Sort.Direction.DESC, "field0", field1, getField2())),
+                Aggregation.sort(sortWithDirection),
+                Aggregation.sort(getSortWithDirection()),
+                // .sort calls with chained .and calls accepting Sort object
+                Aggregation.sort(Sort.by("field0").and(Sort.by(Sort.Direction.DESC, field1)).and(Sort.by(getField2()))),
+                Aggregation.sort(Sort.by("field0").and(firstChainedSort).and(getSecondChainedSort())),
+                // .sort calls with Sort object mixed with Direction enum and Order overloads
+                Aggregation.sort(Sort.Direction.ASC, "field0")
+                    .and(Sort.Direction.DESC, field1)
+                    .and(Sort.by(Sort.Direction.ASC, getField2()))
+                    .and(Sort.by(Sort.Order.desc("field3")))
+                    .and(Sort.by(List.of(Sort.Order.asc("field4"))))
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse sort method call and chained and calls accepting Sort object, Direction enums or Order object and their variants`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        val sortWithoutDirectionExpectation = 3 to listOf(
+            Triple("field0", Name.ASCENDING, 1),
+            Triple("field1", Name.ASCENDING, 1),
+            Triple("field2", Name.ASCENDING, 1),
+        )
+        val sortWithDirectionExpectation = 3 to listOf(
+            Triple("field0", Name.DESCENDING, -1),
+            Triple("field1", Name.DESCENDING, -1),
+            Triple("field2", Name.DESCENDING, -1),
+        )
+        val sortWithChainedAndCalls = 3 to listOf(
+            Triple("field2", Name.ASCENDING, 1),
+            Triple("field1", Name.DESCENDING, -1),
+            Triple("field0", Name.ASCENDING, 1),
+        )
+        parseAndAssertForSortStages(
+            query = query,
+            expectedSortStagesCounts = 9,
+            sortStagesExpectations = listOf(
+                sortWithoutDirectionExpectation,
+                sortWithoutDirectionExpectation,
+                sortWithoutDirectionExpectation,
+                sortWithDirectionExpectation,
+                sortWithDirectionExpectation,
+                sortWithDirectionExpectation,
+                sortWithChainedAndCalls,
+                sortWithChainedAndCalls,
+                5 to listOf(
+                    Triple("field4", Name.ASCENDING, 1),
+                    Triple("field3", Name.DESCENDING, -1),
+                    Triple("field2", Name.ASCENDING, 1),
+                    Triple("field1", Name.DESCENDING, -1),
+                    Triple("field0", Name.ASCENDING, 1),
+                ),
+            )
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.domain.Sort;import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                // Specified direction in some way but forced using chained call
+                Aggregation.sort(Sort.by("field0").descending()),
+                Aggregation.sort(Sort.by(Sort.Direction.ASC, "field0").descending()),
+                Aggregation.sort(Sort.by(Sort.Order.desc("field0")).ascending()),
+                
+                // Last forced direction always takes precedence
+                Aggregation.sort(Sort.by("field0").descending().ascending().ascending().descending()),
+                Aggregation.sort(Sort.by(Sort.Direction.ASC, "field0").descending().ascending().ascending()),
+                Aggregation.sort(Sort.by(Sort.Order.desc("field0")).descending().ascending().ascending()),
+
+                // individual nested chains have their own forced direction
+                Aggregation.sort(
+                    // this chain will have a descending direction
+                    Sort.by("field0").descending()
+                    .and(
+                        // this will have ascending
+                        Sort.by("field1").descending().ascending()
+                    ).and(
+                        // this as well will have ascending
+                        Sort.by(Sort.Direction.DESC, "field2").ascending()
+                    )
+                    .and(
+                        // this as well will have ascending
+                        Sort.by(Sort.Order.desc("field3")).ascending()
+                    )
+                ),
+
+                // forced direction on individual nested chains gets overridden if the parent chain
+                // forces a direction
+                Aggregation.sort(
+                    Sort.by("field0").descending()
+                    .and(
+                        Sort.by("field1").descending().ascending()
+                    ).and(
+                        Sort.by(Sort.Direction.DESC, "field2").ascending()
+                    )
+                    .and(
+                        Sort.by(List.of(Sort.Order.desc("field3"))).ascending()
+                    )
+                    .descending() // now all the chains will have descending direction
+                ),
+
+                // reverse call have no affect if the last chained call is a forced direction
+                Aggregation.sort(Sort.by("field0").reverse().ascending()),
+                
+                // also on the nested chains
+                Aggregation.sort(
+                    // this chain will have a ascending direction
+                    Sort.by("field0").reverse().ascending()
+                    .and(
+                        // this will have ascending
+                        Sort.by("field1").reverse().reverse().ascending()
+                    ).and(
+                        // this as well will have ascending
+                        Sort.by(Sort.Direction.DESC, "field2").reverse().ascending()
+                    )
+                ),
+                Aggregation.sort(
+                    // this chain will have a descending direction
+                    Sort.by("field0").descending()
+                    .and(
+                        // this will have ascending
+                        Sort.by("field1").descending().ascending()
+                    ).and(
+                        // this as well will have ascending
+                        Sort.by(Sort.Direction.DESC, "field2").ascending()
+                    ).and(
+                        Sort.by(List.of(Sort.Order.desc("field3"))).ascending()
+                    ).reverse().descending() // now all the chains will have descending direction
+                )
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse a forced direction using ascending, descending on Sort object and chained calls`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        parseAndAssertForSortStages(
+            query = query,
+            expectedSortStagesCounts = 11,
+            sortStagesExpectations = listOf(
+                1 to listOf(Triple("field0", Name.DESCENDING, -1)),
+                1 to listOf(Triple("field0", Name.DESCENDING, -1)),
+                1 to listOf(Triple("field0", Name.ASCENDING, 1)),
+
+                1 to listOf(Triple("field0", Name.DESCENDING, -1)),
+                1 to listOf(Triple("field0", Name.ASCENDING, 1)),
+                1 to listOf(Triple("field0", Name.ASCENDING, 1)),
+
+                4 to listOf(
+                    Triple("field3", Name.ASCENDING, 1),
+                    Triple("field2", Name.ASCENDING, 1),
+                    Triple("field1", Name.ASCENDING, 1),
+                    Triple("field0", Name.DESCENDING, -1),
+                ),
+
+                4 to listOf(
+                    Triple("field3", Name.DESCENDING, -1),
+                    Triple("field2", Name.DESCENDING, -1),
+                    Triple("field1", Name.DESCENDING, -1),
+                    Triple("field0", Name.DESCENDING, -1),
+                ),
+
+                1 to listOf(Triple("field0", Name.ASCENDING, 1)),
+
+                3 to listOf(
+                    Triple("field2", Name.ASCENDING, 1),
+                    Triple("field1", Name.ASCENDING, 1),
+                    Triple("field0", Name.ASCENDING, 1),
+                ),
+
+                4 to listOf(
+                    Triple("field3", Name.DESCENDING, -1),
+                    Triple("field2", Name.DESCENDING, -1),
+                    Triple("field1", Name.DESCENDING, -1),
+                    Triple("field0", Name.DESCENDING, -1),
+                ),
+            )
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.domain.Sort;import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.sort(
+                    // normal reverse calls should revert the directions
+                    Sort.by("field0").reverse() // descending
+                ),
+                Aggregation.sort(
+                    Sort.by(Sort.Direction.DESC, "field0").reverse() // ascending
+                ),
+                Aggregation.sort(
+                    // multiple reverse calls should be correct applied
+                    Sort.by(Sort.Order.desc("field0")).reverse().reverse().reverse() // ascending
+                ),
+                Aggregation.sort(
+                    // reverse should work well with earlier forced directions
+                    Sort.by("field0").descending().reverse() // ascending
+                ),
+                Aggregation.sort(
+                    Sort.by("field0").ascending().descending().reverse() // ascending
+                ),
+                Aggregation.sort(
+                    // should be ascending
+                    Sort.by("field0").descending().reverse().descending().ascending().reverse().reverse()
+                ),
+                Aggregation.sort(
+                    // reverse should work well in nested chains
+                    Sort.by("field0").reverse() // descending
+                        .and(
+                            Sort.by(Sort.Direction.DESC, "field1").reverse() // ascending
+                        )
+                        .and(
+                            // should be ascending
+                            Sort.by("field2").descending().reverse().descending().ascending().reverse().reverse()
+                        )
+                        .and(
+                            // ascending
+                            Sort.by(Sort.Order.desc("field3")).reverse().descending().ascending().reverse().reverse()
+                        )
+                ),
+                Aggregation.sort(
+                    // reverse on parent chain should revert the entire chain
+                    Sort.by("field0").descending() // descending from nested but will be ascending finally
+                        .and(
+                            Sort.by(Sort.Direction.DESC, "field1").reverse() // ascending from nested but will be descending finally
+                        )
+                        .and(
+                            // should be ascending but will be descending finally
+                            Sort.by("field2").descending().reverse().descending().ascending().reverse().reverse()
+                        )
+                        .and(
+                            // ascending but after reverse will be descending
+                            Sort.by(Sort.Order.desc("field3")).reverse().descending().ascending().reverse().reverse()
+                        )
+                        .reverse()
+                ),
+                // same as above but with a bunch of forced directions and reverse on parent chain
+                Aggregation.sort(
+                    // reverse on parent chain should revert the entire chain
+                    Sort.by("field0").descending() // descending from nested but will be ascending finally
+                        .and(
+                            Sort.by(Sort.Direction.DESC, "field1").reverse() // ascending from nested and ascending finally
+                        )
+                        .and(
+                            // should be ascending and ascending also with parent effect
+                            Sort.by("field2").descending().reverse().descending().ascending().reverse().reverse()
+                        )
+                        .and(
+                            // ascending but after reverse will be descending
+                            Sort.by(List.of(Sort.Order.desc("field3"))).reverse().descending().ascending().reverse().reverse()
+                        )
+                        .descending().reverse().descending().ascending().reverse().reverse()
+                )
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse a reversed direction using reverse on sort and chained calls`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        parseAndAssertForSortStages(
+            query = query,
+            expectedSortStagesCounts = 9,
+            sortStagesExpectations = listOf(
+                1 to listOf(Triple("field0", Name.DESCENDING, -1)),
+                1 to listOf(Triple("field0", Name.ASCENDING, 1)),
+                1 to listOf(Triple("field0", Name.ASCENDING, 1)),
+                1 to listOf(Triple("field0", Name.ASCENDING, 1)),
+                1 to listOf(Triple("field0", Name.ASCENDING, 1)),
+                1 to listOf(Triple("field0", Name.ASCENDING, 1)),
+                4 to listOf(
+                    Triple("field3", Name.ASCENDING, 1),
+                    Triple("field2", Name.ASCENDING, 1),
+                    Triple("field1", Name.ASCENDING, 1),
+                    Triple("field0", Name.DESCENDING, -1),
+                ),
+                4 to listOf(
+                    Triple("field3", Name.DESCENDING, -1),
+                    Triple("field2", Name.DESCENDING, -1),
+                    Triple("field1", Name.DESCENDING, -1),
+                    Triple("field0", Name.ASCENDING, 1),
+                ),
+                4 to listOf(
+                    Triple("field3", Name.ASCENDING, 1),
+                    Triple("field2", Name.ASCENDING, 1),
+                    Triple("field1", Name.ASCENDING, 1),
+                    Triple("field0", Name.ASCENDING, 1),
+                ),
+            )
+        )
+    }
+
+    companion object {
+        fun parseAndAssertForSortStages(
+            query: PsiExpression,
+            expectedSortStagesCounts: Int,
+            sortStagesExpectations: List<Pair<Int, List<Triple<String, Name, Int>>>>
+        ) {
+            SpringCriteriaDialectParser.parse(query).assert(IsCommand.CommandType.AGGREGATE) {
+                component<HasSourceDialect> {
+                    assertEquals(HasSourceDialect.DialectName.SPRING_CRITERIA, name)
+                }
+
+                collection<HasCollectionReference.OnlyCollection<PsiElement>> {
+                    assertEquals("book", collection)
+                }
+
+                component<HasAggregation<PsiElement>> {
+                    assertEquals(
+                        expectedSortStagesCounts,
+                        children.size,
+                        "Expected $expectedSortStagesCounts aggregation stages but found ${children.size}"
+                    )
+                }
+
+                sortStagesExpectations.forEachIndexed {
+                        stageIndex,
+                        (expectedSortCounts, sortExpectations)
+                    ->
+                    stageN(stageIndex, Name.SORT) {
+                        component<HasSorts<PsiElement>> {
+                            assertEquals(
+                                expectedSortCounts,
+                                children.size,
+                                "StageIndex $stageIndex :: Expected $expectedSortCounts sort criteria but found ${children.size}"
+                            )
+                        }
+
+                        sortExpectations.forEachIndexed {
+                                index,
+                                (expectedFieldName, expectedDirection, expectedDirectionValue)
+                            ->
+                            sortN(index, expectedDirection, stageIndex) {
+                                field<HasFieldReference.FromSchema<PsiElement>> {
+                                    assertEquals(
+                                        expectedFieldName,
+                                        fieldName,
+                                        "StageIndex $stageIndex, SortCriteriaIndex: $index :: Expected field with name $expectedFieldName but found field with name $fieldName"
+                                    )
+                                }
+                                value<HasValueReference.Inferred<PsiElement>> {
+                                    assertEquals(
+                                        BsonInt32,
+                                        type,
+                                        "StageIndex $stageIndex, SortCriteriaIndex: $index :: Expected value type BsonInt32 but found $type"
+                                    )
+                                    assertEquals(
+                                        expectedDirectionValue,
+                                        value,
+                                        "StageIndex $stageIndex, SortCriteriaIndex: $index :: Expected direction value to be $expectedDirectionValue but found $value"
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER-IF-ANY>

  eg. fix(type-hint): infer type of a constant for type checking INTELLIJ-1111
-->

## Description
This PR adds support for parsing a sort stage and the commonly used variants / chains / overloads to define a sort stage and sort criteria. To check the list of supported variants please take a look at the covered test cases [here](https://github.com/mongodb/intellij/pull/123/files#diff-1973db5c1be38d28fd484fc01ddcc9256750ab6dae04654d8e911c9599233294).

<!--- Describe your changes in detail so reviewers have enough content on what this PR aims to achieve -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist

- [ ] New tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
- [ ] Changelog is updated accordingly.
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement).

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->