### PR TITLE
chore(ci): address codeql issues in gha workflows

### DIFF
--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,7 +1,19 @@
 name: "Check PR Title"
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled, converted_to_draft, edited]
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - labeled
+      - unlabeled
+      - converted_to_draft
+      - edited
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   check-pr-title:
@@ -9,16 +21,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Enforce conventional commit style
-        uses: realm/ci-actions/title-checker@main
+        uses: realm/ci-actions/title-checker@d6cc8f067474759d38e6d24e272027b4c88bc0a9
         with:
           regex: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|ops){1}(\([\w\-\.]+\))?(!)?: .*'
           error-hint: 'Invalid PR title. Make sure it follows the conventional commit specification (i.e. "<type>(<optional scope>): <description>") or add the no-title-validation label'
-          ignore-labels: 'no-title-validation'
+          ignore-labels: no-title-validation
       - name: Enforce JIRA ticket in title
-        uses: realm/ci-actions/title-checker@main
+        uses: realm/ci-actions/title-checker@d6cc8f067474759d38e6d24e272027b4c88bc0a9
         # Skip the JIRA ticket check for PRs opened by bots
         if: ${{ !contains(github.event.pull_request.user.login, '[bot]') }}
         with:
-          regex: '[A-Z]{4,10}-[0-9]{1,5}$'
-          error-hint: 'Invalid PR title. Make sure it ends with a JIRA ticket - i.e. VSCODE-1234 or add the no-title-validation label'
-          ignore-labels: 'no-title-validation'
+          regex: "[A-Z]{4,10}-[0-9]{1,5}$"
+          error-hint: Invalid PR title. Make sure it ends with a JIRA ticket - i.e. VSCODE-1234 or add the no-title-validation label
+          ignore-labels: no-title-validation

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   prepare-release:
     name: "Prepare Release"

--- a/.github/workflows/quality-check.yaml
+++ b/.github/workflows/quality-check.yaml
@@ -27,7 +27,7 @@ jobs:
           java-version: "17"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@0bdd871935719febd78681f197cd39af5b6e16a6 # 4.2.2
         with:
           dependency-graph: "generate-and-submit"
           dependency-graph-continue-on-failure: false
@@ -51,7 +51,7 @@ jobs:
           java-version: "17"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@0bdd871935719febd78681f197cd39af5b6e16a6 # 4.2.2
         with:
           gradle-home-cache-cleanup: true
 
@@ -79,7 +79,7 @@ jobs:
           java-version: "17"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@0bdd871935719febd78681f197cd39af5b6e16a6 # 4.2.2
         with:
           gradle-home-cache-cleanup: true
 
@@ -91,7 +91,7 @@ jobs:
           sudo install -m 0755 -d /etc/apt/keyrings
           sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
           sudo chmod a+r /etc/apt/keyrings/docker.asc
-          
+
           echo "Adding the repository to APT sources"
           echo \
           "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
@@ -101,7 +101,6 @@ jobs:
 
           echo "Installing docker"
           sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin
-
 
       - name: Run Test Suite
         run: |
@@ -144,7 +143,7 @@ jobs:
 #          java-version: "17"
 #
 #      - name: Setup Gradle
-#        uses: gradle/actions/setup-gradle@v4
+#        uses: gradle/actions/setup-gradle@0bdd871935719febd78681f197cd39af5b6e16a6 # 4.2.2
 #        with:
 #          gradle-home-cache-cleanup: true
 #
@@ -227,7 +226,7 @@ jobs:
           java-version: "17"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@0bdd871935719febd78681f197cd39af5b6e16a6 # 4.2.2
         with:
           gradle-home-cache-cleanup: true
 
@@ -262,7 +261,7 @@ jobs:
           java-version: "17"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@0bdd871935719febd78681f197cd39af5b6e16a6 # 4.2.2
         with:
           gradle-home-cache-cleanup: true
 


### PR DESCRIPTION
## Description

This addresses most issues reported by codeql. The remaining ones are related to using `mongodb-js/devtools-shared/actions/setup-bot-token@main` instead of pinning to a commit. I feel that this should be treated as a first-party action and be exempt from requiring commit pinning, but am open to be convinced otherwise
