### PR TITLE
feat: add support for parsing, inspecting and autocompleting in a group stage written using Spring Data MongoDB INTELLIJ-175

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ MongoDB plugin for IntelliJ IDEA.
 ## [Unreleased]
 
 ### Added
+* [INTELLIJ-175](https://jira.mongodb.org/browse/INTELLIJ-175) Add support for parsing, inspecting and autocompleting in a group stage written using `Aggregation.group` and chained `GroupOperation`s using `sum`, `avg`, `first`, `last`, `max`, `min`, `push` and `addToSet`.
 * [INTELLIJ-196](https://jira.mongodb.org/browse/INTELLIJ-196) Add support for $sort when generating the query into DataGrip.
 * [INTELLIJ-195](https://jira.mongodb.org/browse/INTELLIJ-195) Add support for $unwind when generating the query into DataGrip.
 * [INTELLIJ-194](https://jira.mongodb.org/browse/INTELLIJ-194) Add support for $addFields when generating the query into DataGrip.

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/JavaDriverMongoDbAutocompletionPopupHandlerTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/JavaDriverMongoDbAutocompletionPopupHandlerTest.kt
@@ -6,9 +6,11 @@ import com.mongodb.jbplugin.accessadapter.slice.GetCollectionSchema
 import com.mongodb.jbplugin.accessadapter.slice.ListCollections
 import com.mongodb.jbplugin.accessadapter.slice.ListDatabases
 import com.mongodb.jbplugin.dialects.javadriver.glossary.JavaDriverDialect
+import com.mongodb.jbplugin.dialects.springcriteria.SpringCriteriaDialect
 import com.mongodb.jbplugin.fixtures.CodeInsightTest
 import com.mongodb.jbplugin.fixtures.ParsingTest
 import com.mongodb.jbplugin.fixtures.setupConnection
+import com.mongodb.jbplugin.fixtures.specifyDatabase
 import com.mongodb.jbplugin.fixtures.specifyDialect
 import com.mongodb.jbplugin.mql.BsonObject
 import com.mongodb.jbplugin.mql.BsonString
@@ -1012,6 +1014,925 @@ public class Repository {
         assertTrue(
             elements.containsElements {
                 it.lookupString == "myField"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.group("<caret>")
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Aggregation#group root call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.Fields;import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.group(Fields.fields("<caret>"))
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Aggregation#group root call with Fields#fields`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.Fields;import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.group(Fields.fields(Fields.field("<caret>")))
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Aggregation#group root call with Fields#from(Fields#field)`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.Fields;import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.group()
+                    .sum(<caret>)
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Aggregation#group#sum call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        fixture.type('"')
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.Fields;import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.group()
+                    .avg(<caret>)
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Aggregation#group#avg call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        fixture.type('"')
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.Fields;import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.group()
+                    .first(<caret>)
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Aggregation#group#first call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        fixture.type('"')
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.Fields;import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.group()
+                    .last(<caret>)
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Aggregation#group#last call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        fixture.type('"')
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.Fields;import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.group()
+                    .max(<caret>)
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Aggregation#group#max call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        fixture.type('"')
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.Fields;import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.group()
+                    .min(<caret>)
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Aggregation#group#min call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        fixture.type('"')
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.Fields;import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.group()
+                    .push(<caret>)
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Aggregation#group#push call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        fixture.type('"')
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.Fields;import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.group()
+                    .addToSet(<caret>)
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Aggregation#group#addToSet call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        fixture.type('"')
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.Fields;import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.group()
+                    .sum("asd")
+                    .as(<caret>)
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should not autocomplete fields from the current namespace in Aggregation#group#as call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        fixture.type('"')
+        val elements = fixture.completeBasic()
+
+        assertFalse(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertFalse(
+            elements.containsElements {
+                it.lookupString == "myField2"
             },
         )
     }

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/SpringCriteriaCompletionContributorTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/SpringCriteriaCompletionContributorTest.kt
@@ -10,6 +10,7 @@ import com.mongodb.jbplugin.mql.BsonObject
 import com.mongodb.jbplugin.mql.BsonString
 import com.mongodb.jbplugin.mql.CollectionSchema
 import com.mongodb.jbplugin.mql.Namespace
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.eq
@@ -1828,6 +1829,916 @@ class Repository {
         )
 
         assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.group("<caret>")
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Aggregation#group root call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.Fields;import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.group(Fields.fields("<caret>"))
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Aggregation#group root call with Fields#fields`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.Fields;import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.group(Fields.fields(Fields.field("<caret>")))
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Aggregation#group root call with Fields#from(Fields#field)`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.Fields;import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.group()
+                    .sum("<caret>")
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Aggregation#group#sum call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.Fields;import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.group()
+                    .avg("<caret>")
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Aggregation#group#avg call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.Fields;import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.group()
+                    .first("<caret>")
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Aggregation#group#first call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.Fields;import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.group()
+                    .last("<caret>")
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Aggregation#group#last call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.Fields;import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.group()
+                    .max("<caret>")
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Aggregation#group#max call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.Fields;import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.group()
+                    .min("<caret>")
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Aggregation#group#min call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.Fields;import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.group()
+                    .push("<caret>")
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Aggregation#group#push call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.Fields;import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.group()
+                    .addToSet("<caret>")
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in Aggregation#group#addToSet call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Repository.java",
+        value = """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.Fields;import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.group()
+                    .sum("asd")
+                    .as("<caret>")
+            ),
+            Book.class,
+            Book.class
+        ).getMappedResults();
+    }
+}
+        """,
+    )
+    fun `should not autocomplete fields from the current namespace in Aggregation#group#as call`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertFalse(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertFalse(
             elements.containsElements {
                 it.lookupString == "myField2"
             },

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/impl/SpringCriteriaFieldCheckLinterInspectionTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/impl/SpringCriteriaFieldCheckLinterInspectionTest.kt
@@ -290,7 +290,40 @@ class BookRepository {
                     .addField("addedField").withValueOf(Fields.field(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">"released"</warning>))
                     .addField("addedField").withValueOf(Fields.field(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedAsVariable</warning>))
                     .addField("addedField").withValueOf(Fields.field(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedFromMethodCall()</warning>))
-                    .build()
+                    .build(),
+                
+                Aggregation.group(),
+                Aggregation.group(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">"released"</warning>),
+                Aggregation.group(
+                    <warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">"released"</warning>,
+                    <warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedAsVariable</warning>,
+                    <warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedFromMethodCall()</warning>
+                ),
+                Aggregation.group()
+                    .sum(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">"released"</warning>).as("accumulatedField")
+                    .sum(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedAsVariable</warning>).as("accumulatedField")
+                    .sum(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedFromMethodCall()</warning>).as("accumulatedField")
+                    .avg(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">"released"</warning>).as("accumulatedField")
+                    .avg(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedAsVariable</warning>).as("accumulatedField")
+                    .avg(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedFromMethodCall()</warning>).as("accumulatedField")
+                    .max(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">"released"</warning>).as("accumulatedField")
+                    .max(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedAsVariable</warning>).as("accumulatedField")
+                    .max(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedFromMethodCall()</warning>).as("accumulatedField")
+                    .min(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">"released"</warning>).as("accumulatedField")
+                    .min(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedAsVariable</warning>).as("accumulatedField")
+                    .min(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedFromMethodCall()</warning>).as("accumulatedField")
+                    .first(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">"released"</warning>).as("accumulatedField")
+                    .first(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedAsVariable</warning>).as("accumulatedField")
+                    .first(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedFromMethodCall()</warning>).as("accumulatedField")
+                    .last(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">"released"</warning>).as("accumulatedField")
+                    .last(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedAsVariable</warning>).as("accumulatedField")
+                    .last(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedFromMethodCall()</warning>).as("accumulatedField")
+                    .push(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">"released"</warning>).as("accumulatedField")
+                    .push(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedAsVariable</warning>).as("accumulatedField")
+                    .push(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedFromMethodCall()</warning>).as("accumulatedField")
+                    .addToSet(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">"released"</warning>).as("accumulatedField")
+                    .addToSet(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedAsVariable</warning>).as("accumulatedField")
+                    .addToSet(<warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">releasedFromMethodCall()</warning>).as("accumulatedField")
             ),
             Book.class,
             Book.class

--- a/packages/mongodb-dialects/spring-criteria/src/main/kotlin/com/mongodb/jbplugin/dialects/springcriteria/SpringCriteriaDialectParser.kt
+++ b/packages/mongodb-dialects/spring-criteria/src/main/kotlin/com/mongodb/jbplugin/dialects/springcriteria/SpringCriteriaDialectParser.kt
@@ -11,6 +11,7 @@ import com.mongodb.jbplugin.dialects.springcriteria.QueryTargetCollectionExtract
 import com.mongodb.jbplugin.dialects.springcriteria.QueryTargetCollectionExtractor.extractCollectionFromStringTypeParameter
 import com.mongodb.jbplugin.dialects.springcriteria.QueryTargetCollectionExtractor.or
 import com.mongodb.jbplugin.dialects.springcriteria.aggregationstageparsers.AddFieldsStageParser
+import com.mongodb.jbplugin.dialects.springcriteria.aggregationstageparsers.GroupStageParser
 import com.mongodb.jbplugin.dialects.springcriteria.aggregationstageparsers.MatchStageParser
 import com.mongodb.jbplugin.dialects.springcriteria.aggregationstageparsers.ProjectStageParser
 import com.mongodb.jbplugin.dialects.springcriteria.aggregationstageparsers.SortStageParser
@@ -36,6 +37,7 @@ object SpringCriteriaDialectParser : DialectParser<PsiElement> {
         UnwindStageParser(),
         SortStageParser(),
         AddFieldsStageParser(),
+        GroupStageParser(),
     )
 
     override fun isCandidateForQuery(source: PsiElement) =

--- a/packages/mongodb-dialects/spring-criteria/src/main/kotlin/com/mongodb/jbplugin/dialects/springcriteria/aggregationstageparsers/GroupStageParser.kt
+++ b/packages/mongodb-dialects/spring-criteria/src/main/kotlin/com/mongodb/jbplugin/dialects/springcriteria/aggregationstageparsers/GroupStageParser.kt
@@ -68,7 +68,7 @@ class GroupStageParser : StageParser {
                 when (method.name) {
                     "sum", "avg", "first", "last", "max", "min", "push", "addToSet" -> {
                         parseKeyValueAccumulator(
-                            sumMethodCall = methodCall,
+                            operatorMethodCall = methodCall,
                             // The `.as` method call, if at all chained, should be right before this call
                             // in the gathered chain of calls.
                             asMethodCall = allChainedCalls
@@ -143,10 +143,10 @@ class GroupStageParser : StageParser {
      * option.
      */
     private fun parseKeyValueAccumulator(
-        sumMethodCall: PsiMethodCallExpression,
+        operatorMethodCall: PsiMethodCallExpression,
         asMethodCall: PsiMethodCallExpression?
     ): Node<PsiElement> {
-        val fieldExpressionInSumCall = sumMethodCall.argumentList.expressions.getOrNull(0)
+        val fieldExpressionInSumCall = operatorMethodCall.argumentList.expressions.getOrNull(0)
         // The field passed to sum method call could also be an AggregationExpression, which we
         // do not support parsing yet. So we assume that it is a string and try to parse it as
         // a constant and resolve a ValueReference out of it
@@ -170,12 +170,12 @@ class GroupStageParser : StageParser {
             }
         )
 
-        val sumMethod = sumMethodCall.fuzzyResolveMethod()
+        val operatorMethod = operatorMethodCall.fuzzyResolveMethod()
         return Node(
-            source = asMethodCall ?: sumMethodCall,
+            source = asMethodCall ?: operatorMethodCall,
             listOf(
                 Named(
-                    when (sumMethod?.name) {
+                    when (operatorMethod?.name) {
                         "sum" -> Name.SUM
                         "avg" -> Name.AVG
                         "first" -> Name.FIRST

--- a/packages/mongodb-dialects/spring-criteria/src/main/kotlin/com/mongodb/jbplugin/dialects/springcriteria/aggregationstageparsers/GroupStageParser.kt
+++ b/packages/mongodb-dialects/spring-criteria/src/main/kotlin/com/mongodb/jbplugin/dialects/springcriteria/aggregationstageparsers/GroupStageParser.kt
@@ -1,0 +1,223 @@
+package com.mongodb.jbplugin.dialects.springcriteria.aggregationstageparsers
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiMethodCallExpression
+import com.mongodb.jbplugin.dialects.javadriver.glossary.fuzzyResolveMethod
+import com.mongodb.jbplugin.dialects.javadriver.glossary.parseFieldExpressionAsValueReference
+import com.mongodb.jbplugin.dialects.javadriver.glossary.resolveFieldNameFromExpression
+import com.mongodb.jbplugin.dialects.javadriver.glossary.tryToResolveAsConstantString
+import com.mongodb.jbplugin.dialects.springcriteria.AGGREGATE_FQN
+import com.mongodb.jbplugin.mql.BsonAny
+import com.mongodb.jbplugin.mql.BsonNull
+import com.mongodb.jbplugin.mql.ComputedBsonType
+import com.mongodb.jbplugin.mql.Node
+import com.mongodb.jbplugin.mql.components.HasAccumulatedFields
+import com.mongodb.jbplugin.mql.components.HasFieldReference
+import com.mongodb.jbplugin.mql.components.HasFieldReference.FieldReference
+import com.mongodb.jbplugin.mql.components.HasValueReference
+import com.mongodb.jbplugin.mql.components.HasValueReference.ValueReference
+import com.mongodb.jbplugin.mql.components.Name
+import com.mongodb.jbplugin.mql.components.Named
+
+internal const val GROUP_OPERATION_FQN = "org.springframework.data.mongodb.core.aggregation.GroupOperation"
+internal const val GROUP_OPERATION_BUILDER_FQN = "$GROUP_OPERATION_FQN.GroupOperationBuilder"
+
+class GroupStageParser : StageParser {
+    override fun isSuitableForFieldAutoComplete(
+        methodCall: PsiMethodCallExpression,
+        method: PsiMethod
+    ): Boolean {
+        return canParse(method)
+    }
+
+    override fun canParse(stageCallMethod: PsiMethod): Boolean {
+        return listOf(
+            AGGREGATE_FQN,
+            GROUP_OPERATION_FQN,
+            GROUP_OPERATION_BUILDER_FQN
+        ).contains(stageCallMethod.containingClass?.qualifiedName) &&
+            listOf(
+                "group", "sum", "avg", "first", "last", "max", "min", "push", "addToSet", "as"
+            ).contains(stageCallMethod.name)
+    }
+
+    override fun parse(stageCall: PsiMethodCallExpression): Node<PsiElement> {
+        val allChainedCalls = stageCall.gatherChainedCalls()
+        // In a group stage written in Spring data mongodb, the _id field is specified in the
+        // Aggregation.group() call itself. Generally speaking in a list of chained calls the
+        // last call is the root group call
+        val rootGroupCallWithIdField = allChainedCalls.find { it.isRootGroupCall() }
+        val chainedCallsWithoutRootGroupCall = allChainedCalls.filter { !it.isRootGroupCall() }
+        val (idFieldReference, idValueReference) =
+            parseRootGroupCallToIdFieldAndValueReference(rootGroupCallWithIdField)
+
+        return createGroupStage(
+            stageCall = stageCall,
+            idFieldReference = idFieldReference,
+            idValueReference = idValueReference,
+            accumulatedFields = chainedCallsWithoutRootGroupCall.mapIndexedNotNull {
+                    index,
+                    methodCall
+                ->
+                val method = methodCall.fuzzyResolveMethod() ?: return@mapIndexedNotNull null
+                when (method.name) {
+                    "sum", "avg", "first", "last", "max", "min", "push", "addToSet" -> {
+                        parseKeyValueAccumulator(
+                            sumMethodCall = methodCall,
+                            // The `.as` method call, if at all chained, should be right before this call
+                            // in the gathered chain of calls.
+                            asMethodCall = allChainedCalls
+                                .getOrNull(index - 1)?.takeIf { it.isAsMethodCall() }
+                        )
+                    }
+
+                    else -> null
+                }
+            }
+        )
+    }
+
+    private fun parseRootGroupCallToIdFieldAndValueReference(
+        methodCall: PsiMethodCallExpression?
+    ): Pair<FieldReference<PsiElement>, ValueReference<PsiElement>> {
+        val unknownIdFieldReference = HasFieldReference.Unknown as FieldReference<PsiElement>
+        val unknownIdValueReference = HasValueReference.Unknown as ValueReference<PsiElement>
+        if (methodCall == null) {
+            return unknownIdFieldReference to unknownIdValueReference
+        }
+
+        val idFieldReference = HasFieldReference.Inferred(
+            source = methodCall as PsiElement,
+            fieldName = "_id",
+            displayName = "_id",
+        )
+
+        val method = methodCall.fuzzyResolveMethod()
+            ?: return idFieldReference to unknownIdValueReference
+
+        val fieldStringExpressions = if (method.isVarArgs) {
+            methodCall.argumentList.expressions.toList()
+        } else {
+            val fieldsObjectExpression = methodCall.argumentList.expressions.getOrNull(0)
+            fieldsObjectExpression?.resolveFieldStringExpressionsFromFieldsObject() ?: emptyList()
+        }
+
+        val schemaFieldReferences = fieldStringExpressions.map { fieldExpression ->
+            HasFieldReference(fieldExpression.resolveFieldNameFromExpression())
+        }
+
+        val idValueReference = if (schemaFieldReferences.isNotEmpty()) {
+            HasValueReference.Computed(
+                source = methodCall as PsiElement,
+                type = ComputedBsonType(
+                    baseType = BsonAny,
+                    expression = Node(
+                        source = methodCall,
+                        components = schemaFieldReferences
+                    )
+                )
+            )
+        } else {
+            HasValueReference.Constant(
+                source = methodCall as PsiElement,
+                type = BsonNull,
+                value = null
+            )
+        }
+
+        return idFieldReference to idValueReference
+    }
+
+    /**
+     * Parses a provided method call into a Node representing the accumulated field using one of the
+     * following accumulators: "sum", "avg", "first", "last", "max", "min", "push", "addToSet"
+     *
+     * A key,value accumulator is generally written as: `.sum("fieldInSchema").as("saveAsField")`
+     * Now it might be possible that user is yet to write `.as` part of expression so we treat it
+     * as normal case and try to parse the `.sum` part of the expression with our best failsafe
+     * option.
+     */
+    private fun parseKeyValueAccumulator(
+        sumMethodCall: PsiMethodCallExpression,
+        asMethodCall: PsiMethodCallExpression?
+    ): Node<PsiElement> {
+        val fieldExpressionInSumCall = sumMethodCall.argumentList.expressions.getOrNull(0)
+        // The field passed to sum method call could also be an AggregationExpression, which we
+        // do not support parsing yet. So we assume that it is a string and try to parse it as
+        // a constant and resolve a ValueReference out of it
+        val computedValueReference =
+            fieldExpressionInSumCall?.parseFieldExpressionAsValueReference()
+                ?: HasValueReference(HasValueReference.Unknown)
+
+        val accumulatedFieldExpressionInAsCall =
+            asMethodCall?.argumentList?.expressions?.getOrNull(0)
+        val accumulatedFieldAsString =
+            accumulatedFieldExpressionInAsCall?.tryToResolveAsConstantString()
+        val accumulatedFieldReference = HasFieldReference(
+            if (accumulatedFieldAsString != null) {
+                HasFieldReference.Computed(
+                    source = accumulatedFieldExpressionInAsCall,
+                    fieldName = accumulatedFieldAsString,
+                    displayName = accumulatedFieldAsString
+                )
+            } else {
+                HasFieldReference.Unknown as FieldReference<PsiElement>
+            }
+        )
+
+        val sumMethod = sumMethodCall.fuzzyResolveMethod()
+        return Node(
+            source = asMethodCall ?: sumMethodCall,
+            listOf(
+                Named(
+                    when (sumMethod?.name) {
+                        "sum" -> Name.SUM
+                        "avg" -> Name.AVG
+                        "first" -> Name.FIRST
+                        "last" -> Name.LAST
+                        "max" -> Name.MAX
+                        "min" -> Name.MIN
+                        "push" -> Name.PUSH
+                        "addToSet" -> Name.ADD_TO_SET
+                        else -> Name.UNKNOWN
+                    }
+                ),
+                accumulatedFieldReference,
+                computedValueReference,
+            )
+        )
+    }
+
+    private fun createGroupStage(
+        stageCall: PsiElement,
+        idFieldReference: FieldReference<PsiElement>,
+        idValueReference: ValueReference<PsiElement>,
+        accumulatedFields: List<Node<PsiElement>>
+    ): Node<PsiElement> {
+        return Node(
+            source = stageCall,
+            components = listOf(
+                Named(Name.GROUP),
+                HasFieldReference(idFieldReference),
+                HasValueReference(idValueReference),
+                HasAccumulatedFields(accumulatedFields),
+            )
+        )
+    }
+}
+
+fun PsiMethodCallExpression.isRootGroupCall(): Boolean {
+    val method = fuzzyResolveMethod() ?: return false
+    return method.name == "group" && method.containingClass?.qualifiedName == AGGREGATE_FQN
+}
+
+/**
+ * Confirms if the method call represents `GroupOperation.as()` call.
+ * Generally available to be chained on expressions such as `.sum("someField").as("asField")`
+ */
+fun PsiMethodCallExpression.isAsMethodCall(): Boolean {
+    val method = fuzzyResolveMethod() ?: return false
+    return method.name == "as" &&
+        method.containingClass?.qualifiedName == GROUP_OPERATION_BUILDER_FQN
+}

--- a/packages/mongodb-dialects/spring-criteria/src/test/kotlin/com/mongodb/jbplugin/dialects/springcriteria/IntegrationTest.kt
+++ b/packages/mongodb-dialects/spring-criteria/src/test/kotlin/com/mongodb/jbplugin/dialects/springcriteria/IntegrationTest.kt
@@ -33,6 +33,7 @@ import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
 import com.mongodb.assertions.Assertions.assertNotNull
 import com.mongodb.jbplugin.mql.Component
 import com.mongodb.jbplugin.mql.Node
+import com.mongodb.jbplugin.mql.components.HasAccumulatedFields
 import com.mongodb.jbplugin.mql.components.HasAddedFields
 import com.mongodb.jbplugin.mql.components.HasAggregation
 import com.mongodb.jbplugin.mql.components.HasCollectionReference
@@ -425,6 +426,31 @@ fun Node<PsiElement>.addedFieldN(
     }
 
     addedField.assertions()
+}
+
+fun Node<PsiElement>.accumulatedFieldN(
+    n: Int,
+    name: Name? = null,
+    stageIndex: Int? = null,
+    assertions: Node<PsiElement>.() -> Unit = {
+    },
+) {
+    val accumulatedFields = component<HasAccumulatedFields<PsiElement>>()
+    assertNotNull(accumulatedFields)
+
+    val accumulatedField = accumulatedFields!!.children[n]
+
+    if (name != null) {
+        val qname = accumulatedField.component<Named>()
+        assertNotEquals(null, qname) {
+            "StageIndex: $stageIndex, AccumulatedFieldIndex: $n :: Expected a named operation with name $name but null found."
+        }
+        assertEquals(name, qname?.name) {
+            "StageIndex: $stageIndex, AccumulatedFieldIndex: $n :: Expected a named operation with name $name but $qname found."
+        }
+    }
+
+    accumulatedField.assertions()
 }
 
 fun Node<PsiElement>.updateN(

--- a/packages/mongodb-dialects/spring-criteria/src/test/kotlin/com/mongodb/jbplugin/dialects/springcriteria/aggregationstageparsers/GroupStageParserTest.kt
+++ b/packages/mongodb-dialects/spring-criteria/src/test/kotlin/com/mongodb/jbplugin/dialects/springcriteria/aggregationstageparsers/GroupStageParserTest.kt
@@ -1,0 +1,1264 @@
+package com.mongodb.jbplugin.dialects.springcriteria.aggregationstageparsers
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiExpression
+import com.intellij.psi.PsiFile
+import com.mongodb.jbplugin.dialects.springcriteria.IntegrationTest
+import com.mongodb.jbplugin.dialects.springcriteria.ParsingTest
+import com.mongodb.jbplugin.dialects.springcriteria.SpringCriteriaDialectParser
+import com.mongodb.jbplugin.dialects.springcriteria.accumulatedFieldN
+import com.mongodb.jbplugin.dialects.springcriteria.assert
+import com.mongodb.jbplugin.dialects.springcriteria.collection
+import com.mongodb.jbplugin.dialects.springcriteria.component
+import com.mongodb.jbplugin.dialects.springcriteria.field
+import com.mongodb.jbplugin.dialects.springcriteria.getQueryAtMethod
+import com.mongodb.jbplugin.dialects.springcriteria.stageN
+import com.mongodb.jbplugin.dialects.springcriteria.value
+import com.mongodb.jbplugin.mql.components.HasAccumulatedFields
+import com.mongodb.jbplugin.mql.components.HasAggregation
+import com.mongodb.jbplugin.mql.components.HasCollectionReference
+import com.mongodb.jbplugin.mql.components.HasFieldReference
+import com.mongodb.jbplugin.mql.components.HasSourceDialect
+import com.mongodb.jbplugin.mql.components.HasValueReference
+import com.mongodb.jbplugin.mql.components.IsCommand
+import com.mongodb.jbplugin.mql.components.Name
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+
+@IntegrationTest
+class GroupStageParserTest {
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.AddFieldsOperation;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.GroupOperation;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    GroupOperation getEmptyGroup() {
+        return Aggregation.group();
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        GroupOperation emptyGroup = Aggregation.group();
+        return template.aggregate(
+            Aggregation.newAggregation(
+                Aggregation.group(),
+                emptyGroup, 
+                getEmptyGroup()
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse an empty group stage`(psiFile: PsiFile) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        parseAndAssertForGroupStage(
+            query,
+            3,
+            listOf(
+                null to emptyList(),
+                null to emptyList(),
+                null to emptyList(),
+            )
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.AddFieldsOperation;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.Fields;import org.springframework.data.mongodb.core.aggregation.GroupOperation;import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    String getField0() {
+        return "field0";
+    }
+    
+    String getField2() {
+        return "field2";
+    }
+    
+    GroupOperation getGroupWithSingleStringField() {
+        return Aggregation.group(getField0());
+    }
+    
+    GroupOperation getGroupWithMultipleStringFields() {
+        String field1 = "field1";
+        return Aggregation.group("field0", field1, getField2());
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        String field0 = "field0";
+        String field1 = "field1";
+        GroupOperation groupWithSingleStringField = Aggregation.group(field0);
+        GroupOperation groupWithMultipleStringFields = Aggregation.group("field0", field1, getField2());
+        return template.aggregate(
+            Aggregation.newAggregation(
+                // single _id field as string
+                Aggregation.group("field0"),
+                groupWithSingleStringField,
+                getGroupWithSingleStringField(),
+
+                // multiple _id fields as string
+                Aggregation.group("field0", field1, getField2()),
+                groupWithMultipleStringFields,
+                getGroupWithMultipleStringFields()
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse a group stage with single _id fields passed as varargs of strings`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        println(SpringCriteriaDialectParser.parse(query))
+        parseAndAssertForGroupStage(
+            query,
+            6,
+            listOf(
+                listOf("field0") to emptyList(),
+                listOf("field0") to emptyList(),
+                listOf("field0") to emptyList(),
+                listOf("field0", "field1", "field2") to emptyList(),
+                listOf("field0", "field1", "field2") to emptyList(),
+                listOf("field0", "field1", "field2") to emptyList(),
+            )
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.AddFieldsOperation;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.Fields;import org.springframework.data.mongodb.core.aggregation.GroupOperation;import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    String getField0() {
+        return "field0";
+    }
+    
+    String getField2() {
+        return "field2";
+    }
+    
+    Fields getSingleVarFields() {
+        return Fields.fields(getField0());
+    }
+    
+    Fields getMultipleVarFields() {
+        String field1 = "field1";
+        return Fields.fields("field0", field1, getField2());
+    }
+    
+    GroupOperation getGroupWithSingleField() {
+        return Aggregation.group(Fields.fields(getField0()));
+    }
+    
+    GroupOperation getGroupWithSingleVarField() {
+        return Aggregation.group(getSingleVarFields());
+    }
+    
+    GroupOperation getGroupWithMultipleField() {
+        String field1 = "field1";
+        return Aggregation.group(Fields.fields("field0", field1, getField2()));
+    }
+    
+    GroupOperation getGroupWithMultipleVarField() {
+        String field1 = "field1";
+        return Aggregation.group(getMultipleVarFields());
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        String field0 = "field0";
+        String field1 = "field1";
+        Fields singleVarFields = Fields.fields(field0);
+        Fields multipleVarField = Fields.fields("field0", field1, getField2());
+        GroupOperation groupWithSingleField = Aggregation.group(Fields.fields(field0));
+        GroupOperation groupWithSingleVarField = Aggregation.group(singleVarFields);
+        
+        GroupOperation groupWithMultipleField = Aggregation.group(Fields.fields("field0", field1, getField2()));
+        GroupOperation groupWithMultipleVarField = Aggregation.group(multipleVarField);
+        return template.aggregate(
+            Aggregation.newAggregation(
+                // single _id field as Fields
+                Aggregation.group(Fields.fields("field0")),
+                groupWithSingleField,
+                getGroupWithSingleField(),
+                groupWithSingleVarField,
+                getGroupWithSingleVarField(),
+
+                // multiple _id fields as string
+                Aggregation.group(Fields.fields("field0", field1, getField2())),
+                groupWithMultipleField,
+                getGroupWithMultipleField(),
+                groupWithMultipleVarField,
+                getGroupWithMultipleVarField()
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse a group stage with single _id fields passed as Fields object built with Fields#fields`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        parseAndAssertForGroupStage(
+            query,
+            10,
+            listOf(
+                listOf("field0") to emptyList(),
+                listOf("field0") to emptyList(),
+                listOf("field0") to emptyList(),
+                listOf("field0") to emptyList(),
+                listOf("field0") to emptyList(),
+                listOf("field0", "field1", "field2") to emptyList(),
+                listOf("field0", "field1", "field2") to emptyList(),
+                listOf("field0", "field1", "field2") to emptyList(),
+                listOf("field0", "field1", "field2") to emptyList(),
+                listOf("field0", "field1", "field2") to emptyList(),
+            )
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.AddFieldsOperation;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.Fields;
+import org.springframework.data.mongodb.core.aggregation.GroupOperation;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    String getField0() {
+        return "field0";
+    }
+    
+    String getField2() {
+        return "field2";
+    }
+    
+    Fields.Field getSingleVarFields() {
+        return Fields.field(getField0());
+    }
+    
+    Fields getMultipleVarFields() {
+        String field1 = "field1";
+        return Fields.from(
+            Fields.field("field0"),
+            Fields.field(field1),
+            Fields.field(getField2())
+        );
+    }
+    
+    GroupOperation getGroupWithSingleField() {
+        return Aggregation.group(Fields.from(Fields.field(getField0())));
+    }
+    
+    GroupOperation getGroupWithSingleVarField() {
+        return Aggregation.group(Fields.from(getSingleVarFields()));
+    }
+    
+    GroupOperation getGroupWithMultipleField() {
+        String field1 = "field1";
+        return Aggregation.group(Fields.from(
+            Fields.field("field0"),
+            Fields.field(field1),
+            Fields.field(getField2())
+        ));
+    }
+    
+    GroupOperation getGroupWithMultipleVarField() {
+        String field1 = "field1";
+        return Aggregation.group(getMultipleVarFields());
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        String field0 = "field0";
+        String field1 = "field1";
+        Fields.Field singleVarFields = Fields.field(field0);
+        Fields multipleVarField = Fields.from(
+            Fields.field("field0"),
+            Fields.field(field1),
+            Fields.field(getField2())
+        );
+        GroupOperation groupWithSingleField = Aggregation.group(Fields.from(Fields.field("field0")));
+        GroupOperation groupWithSingleVarField = Aggregation.group(Fields.from(singleVarFields));
+        
+        GroupOperation groupWithMultipleField = Aggregation.group(
+            Fields.from(Fields.field("field0"), Fields.field(field1), Fields.field(getField2()))
+        );
+        GroupOperation groupWithMultipleVarField = Aggregation.group(multipleVarField);
+        return template.aggregate(
+            Aggregation.newAggregation(
+                // single _id field as Fields
+                Aggregation.group(Fields.from(Fields.field("field0"))),
+                groupWithSingleField,
+                getGroupWithSingleField(),
+                groupWithSingleVarField,
+                getGroupWithSingleVarField(),
+
+                // multiple _id fields as string
+                Aggregation.group(
+                    Fields.from(
+                        Fields.field("field0"),
+                        Fields.field(field1),
+                        Fields.field(getField2())
+                    )
+                ),
+                groupWithMultipleField,
+                getGroupWithMultipleField(),
+                groupWithMultipleVarField,
+                getGroupWithMultipleVarField()
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse a group stage with single _id fields passed as Fields object built with Fields#from(Fields#field())`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        parseAndAssertForGroupStage(
+            query,
+            10,
+            listOf(
+                listOf("field0") to emptyList(),
+                listOf("field0") to emptyList(),
+                listOf("field0") to emptyList(),
+                listOf("field0") to emptyList(),
+                listOf("field0") to emptyList(),
+                listOf("field0", "field1", "field2") to emptyList(),
+                listOf("field0", "field1", "field2") to emptyList(),
+                listOf("field0", "field1", "field2") to emptyList(),
+                listOf("field0", "field1", "field2") to emptyList(),
+                listOf("field0", "field1", "field2") to emptyList(),
+            )
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.AddFieldsOperation;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.GroupOperation;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    String getFieldFromSchemaVar() {
+        return "fieldFromSchema";
+    }
+    
+    Strin getAccumulatedFieldVar() {
+        return "accumulatedField";
+    }
+    
+    GroupOperation.GroupOperationBuilder getCompleteSumChain() {
+        return Aggregation.group("idField").sum(getFieldFromSchemaVar()).as(getAccumulatedFieldVar());
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        String fieldFromSchemaVar = "fieldFromSchema";
+        String accumulatedFieldVar = "accumulatedField";
+        GroupOperation.GroupOperationBuilder partialSumChain = Aggregation.group("idField").sum(fieldFromSchemaVar);
+        GroupOperation.GroupOperationBuilder completeSumChain = Aggregation.group("idField").sum(fieldFromSchemaVar).as(accumulatedFieldVar);
+        return template.aggregate(
+            Aggregation.newAggregation(
+                // an empty sum call
+                Aggregation.group().sum(),
+                // this is an incorrect group operation, but we should be able to parse it
+                Aggregation.group().sum("fieldFromSchema"),
+                Aggregation.group().sum("fieldFromSchema").as("accumulatedField"),
+                Aggregation.group("idField").sum("fieldFromSchema").as("accumulatedField"),
+                
+                // with some variables dropped in
+                partialSumChain,
+                completeSumChain,
+                getCompleteSumChain(),
+
+                // multiple chains
+                Aggregation.group()
+                    .sum("fieldFromSchema").as("accumulatedField")
+                    .sum("field1FromSchema").as("accumulatedField1")
+                    .sum("field2FromSchema")
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse a sum accumulator`(psiFile: PsiFile) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        parseAndAssertForGroupStage(
+            query,
+            8,
+            listOf(
+                null to listOf(Triple(Name.SUM, null, null)),
+                null to listOf(Triple(Name.SUM, "fieldFromSchema", null)),
+                null to listOf(Triple(Name.SUM, "fieldFromSchema", "accumulatedField")),
+                listOf(
+                    "idField"
+                ) to listOf(Triple(Name.SUM, "fieldFromSchema", "accumulatedField")),
+                listOf("idField") to listOf(Triple(Name.SUM, "fieldFromSchema", null)),
+                listOf(
+                    "idField"
+                ) to listOf(Triple(Name.SUM, "fieldFromSchema", "accumulatedField")),
+                listOf(
+                    "idField"
+                ) to listOf(Triple(Name.SUM, "fieldFromSchema", "accumulatedField")),
+                null to listOf(
+                    Triple(Name.SUM, "field2FromSchema", null),
+                    Triple(Name.SUM, "field1FromSchema", "accumulatedField1"),
+                    Triple(Name.SUM, "fieldFromSchema", "accumulatedField"),
+                ),
+            )
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.AddFieldsOperation;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.GroupOperation;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    String getFieldFromSchemaVar() {
+        return "fieldFromSchema";
+    }
+    
+    Strin getAccumulatedFieldVar() {
+        return "accumulatedField";
+    }
+    
+    GroupOperation.GroupOperationBuilder getCompleteChain() {
+        return Aggregation.group("idField").avg(getFieldFromSchemaVar()).as(getAccumulatedFieldVar());
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        String fieldFromSchemaVar = "fieldFromSchema";
+        String accumulatedFieldVar = "accumulatedField";
+        GroupOperation.GroupOperationBuilder partialChain = Aggregation.group("idField").avg(fieldFromSchemaVar);
+        GroupOperation.GroupOperationBuilder completeChain = Aggregation.group("idField").avg(fieldFromSchemaVar).as(accumulatedFieldVar);
+        return template.aggregate(
+            Aggregation.newAggregation(
+                // an empty sum call
+                Aggregation.group().avg(),
+                // this is an incorrect group operation, but we should be able to parse it
+                Aggregation.group().avg("fieldFromSchema"),
+                Aggregation.group().avg("fieldFromSchema").as("accumulatedField"),
+                Aggregation.group("idField").avg("fieldFromSchema").as("accumulatedField"),
+                
+                // with some variables dropped in
+                partialChain,
+                completeChain,
+                getCompleteChain(),
+
+                // multiple chains
+                Aggregation.group()
+                    .avg("fieldFromSchema").as("accumulatedField")
+                    .avg("field1FromSchema").as("accumulatedField1")
+                    .avg("field2FromSchema")
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse an avg accumulator`(psiFile: PsiFile) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        parseAndAssertForGroupStage(
+            query,
+            8,
+            listOf(
+                null to listOf(Triple(Name.AVG, null, null)),
+                null to listOf(Triple(Name.AVG, "fieldFromSchema", null)),
+                null to listOf(Triple(Name.AVG, "fieldFromSchema", "accumulatedField")),
+                listOf(
+                    "idField"
+                ) to listOf(Triple(Name.AVG, "fieldFromSchema", "accumulatedField")),
+                listOf("idField") to listOf(Triple(Name.AVG, "fieldFromSchema", null)),
+                listOf(
+                    "idField"
+                ) to listOf(Triple(Name.AVG, "fieldFromSchema", "accumulatedField")),
+                listOf(
+                    "idField"
+                ) to listOf(Triple(Name.AVG, "fieldFromSchema", "accumulatedField")),
+                null to listOf(
+                    Triple(Name.AVG, "field2FromSchema", null),
+                    Triple(Name.AVG, "field1FromSchema", "accumulatedField1"),
+                    Triple(Name.AVG, "fieldFromSchema", "accumulatedField"),
+                ),
+            )
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.AddFieldsOperation;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.GroupOperation;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    String getFieldFromSchemaVar() {
+        return "fieldFromSchema";
+    }
+    
+    Strin getAccumulatedFieldVar() {
+        return "accumulatedField";
+    }
+    
+    GroupOperation.GroupOperationBuilder getCompleteChain() {
+        return Aggregation.group("idField").first(getFieldFromSchemaVar()).as(getAccumulatedFieldVar());
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        String fieldFromSchemaVar = "fieldFromSchema";
+        String accumulatedFieldVar = "accumulatedField";
+        GroupOperation.GroupOperationBuilder partialChain = Aggregation.group("idField").first(fieldFromSchemaVar);
+        GroupOperation.GroupOperationBuilder completeChain = Aggregation.group("idField").first(fieldFromSchemaVar).as(accumulatedFieldVar);
+        return template.aggregate(
+            Aggregation.newAggregation(
+                // an empty sum call
+                Aggregation.group().first(),
+                // this is an incorrect group operation, but we should be able to parse it
+                Aggregation.group().first("fieldFromSchema"),
+                Aggregation.group().first("fieldFromSchema").as("accumulatedField"),
+                Aggregation.group("idField").first("fieldFromSchema").as("accumulatedField"),
+                
+                // with some variables dropped in
+                partialChain,
+                completeChain,
+                getCompleteChain(),
+
+                // multiple chains
+                Aggregation.group()
+                    .first("fieldFromSchema").as("accumulatedField")
+                    .first("field1FromSchema").as("accumulatedField1")
+                    .first("field2FromSchema")
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse a first accumulator`(psiFile: PsiFile) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        parseAndAssertForGroupStage(
+            query,
+            8,
+            listOf(
+                null to listOf(Triple(Name.FIRST, null, null)),
+                null to listOf(Triple(Name.FIRST, "fieldFromSchema", null)),
+                null to listOf(Triple(Name.FIRST, "fieldFromSchema", "accumulatedField")),
+                listOf("idField") to
+                    listOf(Triple(Name.FIRST, "fieldFromSchema", "accumulatedField")),
+                listOf("idField") to listOf(Triple(Name.FIRST, "fieldFromSchema", null)),
+                listOf("idField") to
+                    listOf(Triple(Name.FIRST, "fieldFromSchema", "accumulatedField")),
+                listOf("idField") to
+                    listOf(Triple(Name.FIRST, "fieldFromSchema", "accumulatedField")),
+                null to listOf(
+                    Triple(Name.FIRST, "field2FromSchema", null),
+                    Triple(Name.FIRST, "field1FromSchema", "accumulatedField1"),
+                    Triple(Name.FIRST, "fieldFromSchema", "accumulatedField"),
+                ),
+            )
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.AddFieldsOperation;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.GroupOperation;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    String getFieldFromSchemaVar() {
+        return "fieldFromSchema";
+    }
+    
+    Strin getAccumulatedFieldVar() {
+        return "accumulatedField";
+    }
+    
+    GroupOperation.GroupOperationBuilder getCompleteChain() {
+        return Aggregation.group("idField").last(getFieldFromSchemaVar()).as(getAccumulatedFieldVar());
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        String fieldFromSchemaVar = "fieldFromSchema";
+        String accumulatedFieldVar = "accumulatedField";
+        GroupOperation.GroupOperationBuilder partialChain = Aggregation.group("idField").last(fieldFromSchemaVar);
+        GroupOperation.GroupOperationBuilder completeChain = Aggregation.group("idField").last(fieldFromSchemaVar).as(accumulatedFieldVar);
+        return template.aggregate(
+            Aggregation.newAggregation(
+                // an empty sum call
+                Aggregation.group().last(),
+                // this is an incorrect group operation, but we should be able to parse it
+                Aggregation.group().last("fieldFromSchema"),
+                Aggregation.group().last("fieldFromSchema").as("accumulatedField"),
+                Aggregation.group("idField").last("fieldFromSchema").as("accumulatedField"),
+                
+                // with some variables dropped in
+                partialChain,
+                completeChain,
+                getCompleteChain(),
+
+                // multiple chains
+                Aggregation.group()
+                    .last("fieldFromSchema").as("accumulatedField")
+                    .last("field1FromSchema").as("accumulatedField1")
+                    .last("field2FromSchema")
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse a last accumulator`(psiFile: PsiFile) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        parseAndAssertForGroupStage(
+            query,
+            8,
+            listOf(
+                null to listOf(Triple(Name.LAST, null, null)),
+                null to listOf(Triple(Name.LAST, "fieldFromSchema", null)),
+                null to listOf(Triple(Name.LAST, "fieldFromSchema", "accumulatedField")),
+                listOf("idField") to
+                    listOf(Triple(Name.LAST, "fieldFromSchema", "accumulatedField")),
+                listOf("idField") to listOf(Triple(Name.LAST, "fieldFromSchema", null)),
+                listOf("idField") to
+                    listOf(Triple(Name.LAST, "fieldFromSchema", "accumulatedField")),
+                listOf("idField") to
+                    listOf(Triple(Name.LAST, "fieldFromSchema", "accumulatedField")),
+                null to listOf(
+                    Triple(Name.LAST, "field2FromSchema", null),
+                    Triple(Name.LAST, "field1FromSchema", "accumulatedField1"),
+                    Triple(Name.LAST, "fieldFromSchema", "accumulatedField"),
+                ),
+            )
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.AddFieldsOperation;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.GroupOperation;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    String getFieldFromSchemaVar() {
+        return "fieldFromSchema";
+    }
+    
+    Strin getAccumulatedFieldVar() {
+        return "accumulatedField";
+    }
+    
+    GroupOperation.GroupOperationBuilder getCompleteChain() {
+        return Aggregation.group("idField").max(getFieldFromSchemaVar()).as(getAccumulatedFieldVar());
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        String fieldFromSchemaVar = "fieldFromSchema";
+        String accumulatedFieldVar = "accumulatedField";
+        GroupOperation.GroupOperationBuilder partialChain = Aggregation.group("idField").max(fieldFromSchemaVar);
+        GroupOperation.GroupOperationBuilder completeChain = Aggregation.group("idField").max(fieldFromSchemaVar).as(accumulatedFieldVar);
+        return template.aggregate(
+            Aggregation.newAggregation(
+                // an empty sum call
+                Aggregation.group().max(),
+                // this is an incorrect group operation, but we should be able to parse it
+                Aggregation.group().max("fieldFromSchema"),
+                Aggregation.group().max("fieldFromSchema").as("accumulatedField"),
+                Aggregation.group("idField").max("fieldFromSchema").as("accumulatedField"),
+                
+                // with some variables dropped in
+                partialChain,
+                completeChain,
+                getCompleteChain(),
+
+                // multiple chains
+                Aggregation.group()
+                    .max("fieldFromSchema").as("accumulatedField")
+                    .max("field1FromSchema").as("accumulatedField1")
+                    .max("field2FromSchema")
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse a max accumulator`(psiFile: PsiFile) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        parseAndAssertForGroupStage(
+            query,
+            8,
+            listOf(
+                null to listOf(Triple(Name.MAX, null, null)),
+                null to listOf(Triple(Name.MAX, "fieldFromSchema", null)),
+                null to listOf(Triple(Name.MAX, "fieldFromSchema", "accumulatedField")),
+                listOf(
+                    "idField"
+                ) to listOf(Triple(Name.MAX, "fieldFromSchema", "accumulatedField")),
+                listOf("idField") to listOf(Triple(Name.MAX, "fieldFromSchema", null)),
+                listOf(
+                    "idField"
+                ) to listOf(Triple(Name.MAX, "fieldFromSchema", "accumulatedField")),
+                listOf(
+                    "idField"
+                ) to listOf(Triple(Name.MAX, "fieldFromSchema", "accumulatedField")),
+                null to listOf(
+                    Triple(Name.MAX, "field2FromSchema", null),
+                    Triple(Name.MAX, "field1FromSchema", "accumulatedField1"),
+                    Triple(Name.MAX, "fieldFromSchema", "accumulatedField"),
+                ),
+            )
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.AddFieldsOperation;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.GroupOperation;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    String getFieldFromSchemaVar() {
+        return "fieldFromSchema";
+    }
+    
+    Strin getAccumulatedFieldVar() {
+        return "accumulatedField";
+    }
+    
+    GroupOperation.GroupOperationBuilder getCompleteChain() {
+        return Aggregation.group("idField").min(getFieldFromSchemaVar()).as(getAccumulatedFieldVar());
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        String fieldFromSchemaVar = "fieldFromSchema";
+        String accumulatedFieldVar = "accumulatedField";
+        GroupOperation.GroupOperationBuilder partialChain = Aggregation.group("idField").min(fieldFromSchemaVar);
+        GroupOperation.GroupOperationBuilder completeChain = Aggregation.group("idField").min(fieldFromSchemaVar).as(accumulatedFieldVar);
+        return template.aggregate(
+            Aggregation.newAggregation(
+                // an empty sum call
+                Aggregation.group().min(),
+                // this is an incorrect group operation, but we should be able to parse it
+                Aggregation.group().min("fieldFromSchema"),
+                Aggregation.group().min("fieldFromSchema").as("accumulatedField"),
+                Aggregation.group("idField").min("fieldFromSchema").as("accumulatedField"),
+                
+                // with some variables dropped in
+                partialChain,
+                completeChain,
+                getCompleteChain(),
+
+                // multiple chains
+                Aggregation.group()
+                    .min("fieldFromSchema").as("accumulatedField")
+                    .min("field1FromSchema").as("accumulatedField1")
+                    .min("field2FromSchema")
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse a min accumulator`(psiFile: PsiFile) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        parseAndAssertForGroupStage(
+            query,
+            8,
+            listOf(
+                null to listOf(Triple(Name.MIN, null, null)),
+                null to listOf(Triple(Name.MIN, "fieldFromSchema", null)),
+                null to listOf(Triple(Name.MIN, "fieldFromSchema", "accumulatedField")),
+                listOf(
+                    "idField"
+                ) to listOf(Triple(Name.MIN, "fieldFromSchema", "accumulatedField")),
+                listOf("idField") to listOf(Triple(Name.MIN, "fieldFromSchema", null)),
+                listOf(
+                    "idField"
+                ) to listOf(Triple(Name.MIN, "fieldFromSchema", "accumulatedField")),
+                listOf(
+                    "idField"
+                ) to listOf(Triple(Name.MIN, "fieldFromSchema", "accumulatedField")),
+                null to listOf(
+                    Triple(Name.MIN, "field2FromSchema", null),
+                    Triple(Name.MIN, "field1FromSchema", "accumulatedField1"),
+                    Triple(Name.MIN, "fieldFromSchema", "accumulatedField"),
+                ),
+            )
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.AddFieldsOperation;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.GroupOperation;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    String getFieldFromSchemaVar() {
+        return "fieldFromSchema";
+    }
+    
+    Strin getAccumulatedFieldVar() {
+        return "accumulatedField";
+    }
+    
+    GroupOperation.GroupOperationBuilder getCompleteChain() {
+        return Aggregation.group("idField").push(getFieldFromSchemaVar()).as(getAccumulatedFieldVar());
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        String fieldFromSchemaVar = "fieldFromSchema";
+        String accumulatedFieldVar = "accumulatedField";
+        GroupOperation.GroupOperationBuilder partialChain = Aggregation.group("idField").push(fieldFromSchemaVar);
+        GroupOperation.GroupOperationBuilder completeChain = Aggregation.group("idField").push(fieldFromSchemaVar).as(accumulatedFieldVar);
+        return template.aggregate(
+            Aggregation.newAggregation(
+                // an empty sum call
+                Aggregation.group().push(),
+                // this is an incorrect group operation, but we should be able to parse it
+                Aggregation.group().push("fieldFromSchema"),
+                Aggregation.group().push("fieldFromSchema").as("accumulatedField"),
+                Aggregation.group("idField").push("fieldFromSchema").as("accumulatedField"),
+                
+                // with some variables dropped in
+                partialChain,
+                completeChain,
+                getCompleteChain(),
+
+                // multiple chains
+                Aggregation.group()
+                    .push("fieldFromSchema").as("accumulatedField")
+                    .push("field1FromSchema").as("accumulatedField1")
+                    .push("field2FromSchema")
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse a push accumulator`(psiFile: PsiFile) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        parseAndAssertForGroupStage(
+            query,
+            8,
+            listOf(
+                null to listOf(Triple(Name.PUSH, null, null)),
+                null to listOf(Triple(Name.PUSH, "fieldFromSchema", null)),
+                null to listOf(Triple(Name.PUSH, "fieldFromSchema", "accumulatedField")),
+                listOf("idField") to
+                    listOf(Triple(Name.PUSH, "fieldFromSchema", "accumulatedField")),
+                listOf("idField") to listOf(Triple(Name.PUSH, "fieldFromSchema", null)),
+                listOf("idField") to
+                    listOf(Triple(Name.PUSH, "fieldFromSchema", "accumulatedField")),
+                listOf("idField") to
+                    listOf(Triple(Name.PUSH, "fieldFromSchema", "accumulatedField")),
+                null to listOf(
+                    Triple(Name.PUSH, "field2FromSchema", null),
+                    Triple(Name.PUSH, "field1FromSchema", "accumulatedField1"),
+                    Triple(Name.PUSH, "fieldFromSchema", "accumulatedField"),
+                ),
+            )
+        )
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.AddFieldsOperation;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.GroupOperation;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    String getFieldFromSchemaVar() {
+        return "fieldFromSchema";
+    }
+    
+    Strin getAccumulatedFieldVar() {
+        return "accumulatedField";
+    }
+    
+    GroupOperation.GroupOperationBuilder getCompleteChain() {
+        return Aggregation.group("idField").addToSet(getFieldFromSchemaVar()).as(getAccumulatedFieldVar());
+    }
+    
+    public AggregationResults<Book> allReleasedBooks() {
+        String fieldFromSchemaVar = "fieldFromSchema";
+        String accumulatedFieldVar = "accumulatedField";
+        GroupOperation.GroupOperationBuilder partialChain = Aggregation.group("idField").addToSet(fieldFromSchemaVar);
+        GroupOperation.GroupOperationBuilder completeChain = Aggregation.group("idField").addToSet(fieldFromSchemaVar).as(accumulatedFieldVar);
+        return template.aggregate(
+            Aggregation.newAggregation(
+                // an empty sum call
+                Aggregation.group().addToSet(),
+                // this is an incorrect group operation, but we should be able to parse it
+                Aggregation.group().addToSet("fieldFromSchema"),
+                Aggregation.group().addToSet("fieldFromSchema").as("accumulatedField"),
+                Aggregation.group("idField").addToSet("fieldFromSchema").as("accumulatedField"),
+                
+                // with some variables dropped in
+                partialChain,
+                completeChain,
+                getCompleteChain(),
+
+                // multiple chains
+                Aggregation.group()
+                    .addToSet("fieldFromSchema").as("accumulatedField")
+                    .addToSet("field1FromSchema").as("accumulatedField1")
+                    .addToSet("field2FromSchema")
+            ),
+            Book.class,
+            Book.class
+        );
+    }
+}
+        """
+    )
+    fun `should be able to parse a addToSet accumulator`(psiFile: PsiFile) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        parseAndAssertForGroupStage(
+            query,
+            8,
+            listOf(
+                null to listOf(Triple(Name.ADD_TO_SET, null, null)),
+                null to listOf(Triple(Name.ADD_TO_SET, "fieldFromSchema", null)),
+                null to listOf(Triple(Name.ADD_TO_SET, "fieldFromSchema", "accumulatedField")),
+                listOf("idField") to
+                    listOf(Triple(Name.ADD_TO_SET, "fieldFromSchema", "accumulatedField")),
+                listOf("idField") to listOf(Triple(Name.ADD_TO_SET, "fieldFromSchema", null)),
+                listOf("idField") to
+                    listOf(Triple(Name.ADD_TO_SET, "fieldFromSchema", "accumulatedField")),
+                listOf("idField") to
+                    listOf(Triple(Name.ADD_TO_SET, "fieldFromSchema", "accumulatedField")),
+                null to listOf(
+                    Triple(Name.ADD_TO_SET, "field2FromSchema", null),
+                    Triple(Name.ADD_TO_SET, "field1FromSchema", "accumulatedField1"),
+                    Triple(Name.ADD_TO_SET, "fieldFromSchema", "accumulatedField"),
+                ),
+            )
+        )
+    }
+
+    companion object {
+        fun parseAndAssertForGroupStage(
+            query: PsiExpression,
+            expectedGroupStagesCount: Int,
+            groupStagesExpectations: List<
+                Pair<
+                    // list of expectations for id field references or null if _id will be null
+                    List<String>?,
+                    // list of expectations for accumulated fields
+                    List<Triple<Name, String?, String?>>
+                    >
+                >
+        ) {
+            SpringCriteriaDialectParser.parse(query).assert(IsCommand.CommandType.AGGREGATE) {
+                component<HasSourceDialect> {
+                    assertEquals(HasSourceDialect.DialectName.SPRING_CRITERIA, name)
+                }
+
+                collection<HasCollectionReference.OnlyCollection<PsiElement>> {
+                    assertEquals("book", collection)
+                }
+
+                component<HasAggregation<PsiElement>> {
+                    assertEquals(
+                        expectedGroupStagesCount,
+                        children.size,
+                        "Expected $expectedGroupStagesCount aggregation stages but found ${children.size}"
+                    )
+                }
+
+                groupStagesExpectations.forEachIndexed { stageIndex, stageExpectation ->
+                    val (idFieldExpectations, accumulatedFieldExpectations) = stageExpectation
+                    stageN(stageIndex, Name.GROUP) {
+                        field<HasFieldReference.Inferred<PsiElement>> {
+                            assertEquals(
+                                "_id",
+                                fieldName,
+                                "StageIndex $stageIndex :: Expected inferred field reference to have name _id but found $fieldName"
+                            )
+                        }
+
+                        if (idFieldExpectations == null) {
+                            value<HasValueReference.Constant<PsiElement>> {
+                                assertEquals(
+                                    null,
+                                    value,
+                                    "StageIndex $stageIndex, idFieldIndex :: Expected null value for ValueReference corresponding to _id FieldReference but found $value"
+                                )
+                            }
+                        } else {
+                            idFieldExpectations.forEachIndexed { idFieldIndex, expectedFieldName ->
+                                value<HasValueReference.Computed<PsiElement>> {
+                                    val referencedSchemaFields =
+                                        type.expression.components<HasFieldReference<PsiElement>>()
+                                    assertEquals(
+                                        idFieldExpectations.size,
+                                        referencedSchemaFields.size,
+                                        "StageIndex $stageIndex :: Expected ${idFieldExpectations.size} schema field references in Computed value reference of _id but found ${referencedSchemaFields.size}"
+                                    )
+
+                                    val referencedField = referencedSchemaFields[idFieldIndex]
+                                    val reference =
+                                        referencedField.reference as? HasFieldReference.FromSchema<PsiElement>
+                                    assertNotNull(
+                                        reference,
+                                        "StageIndex $stageIndex, idFieldIndex $idFieldIndex :: No Schema field reference found"
+                                    )
+
+                                    assertEquals(
+                                        reference!!.fieldName,
+                                        expectedFieldName
+                                    )
+                                }
+                            }
+                        }
+
+                        component<HasAccumulatedFields<PsiElement>> {
+                            assertEquals(
+                                accumulatedFieldExpectations.size,
+                                children.size,
+                                "StageIndex $stageIndex :: Expected ${accumulatedFieldExpectations.size} accumulated fields, found ${children.size}"
+                            )
+                        }
+
+                        accumulatedFieldExpectations.forEachIndexed {
+                                accumulatorIndex,
+                                accumulatedFieldExpectation
+                            ->
+                            val (operatorName, schemaRefFieldName, accumulatedFieldName) = accumulatedFieldExpectation
+                            accumulatedFieldN(
+                                n = accumulatorIndex,
+                                name = operatorName,
+                                stageIndex = stageIndex,
+                            ) {
+                                if (accumulatedFieldName != null) {
+                                    field<HasFieldReference.Computed<PsiElement>> {
+                                        assertEquals(
+                                            accumulatedFieldName,
+                                            fieldName,
+                                            "StageIndex $stageIndex, AccumulatorIndex $accumulatorIndex :: Expected computed field name to be $accumulatedFieldName, but found $fieldName"
+                                        )
+                                    }
+                                }
+
+                                if (schemaRefFieldName != null) {
+                                    value<HasValueReference.Computed<PsiElement>> {
+                                        val reference =
+                                            type.expression.component<HasFieldReference<PsiElement>>()?.reference as? HasFieldReference.FromSchema<PsiElement>
+
+                                        assertNotNull(
+                                            reference,
+                                            "StageIndex $stageIndex, AccumulatorIndex $accumulatorIndex :: Expected referenced schema field to at-least have $schemaRefFieldName, found nothing"
+                                        )
+
+                                        assertEquals(
+                                            reference!!.fieldName,
+                                            schemaRefFieldName
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/Parser.kt
+++ b/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/Parser.kt
@@ -217,6 +217,20 @@ fun <I, E, O, E2, O2> Parser<I, E, List<O>>.mapMany(
     }
 }
 
+/**
+ * Returns a parser that runs a parser for each element of the output list.
+ */
+fun <I, E, O> Parser<I, E, List<O?>>.filterNotNullMany(): Parser<I, Either<E, Nothing>, List<O>> {
+    return { input ->
+        when (val result = this(input)) {
+            is Either.Left -> Either.left(Either.left(result.value))
+            is Either.Right -> {
+                Either.right(result.value.filterNotNull())
+            }
+        }
+    }
+}
+
 data object NoConditionFulfilled
 
 fun <I, E> equals(toValue: I): Parser<I, E, Boolean> {

--- a/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/components/HasFieldReference.kt
+++ b/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/parser/components/HasFieldReference.kt
@@ -18,8 +18,23 @@ inline fun <reified T : HasFieldReference.FieldReference<S>, S> fieldReference()
         }
     }
 }
+inline fun <reified T : HasFieldReference.FieldReference<S>, S> fieldReferences(): Parser<Node<S>, NoFieldReference, List<T>> {
+    return { input ->
+        val refs = input.components<HasFieldReference<S>>().filter {
+            it.reference is T
+        }.map { it.reference as T }
+
+        if (refs.isNotEmpty()) {
+            Either.right(refs)
+        } else {
+            Either.left(NoFieldReference)
+        }
+    }
+}
 
 fun <S> schemaFieldReference() = fieldReference<HasFieldReference.FromSchema<S>, S>()
+
+fun <S> schemaFieldReferences() = fieldReferences<HasFieldReference.FromSchema<S>, S>()
 
 fun <S> allNodesWithSchemaFieldReferences(): Parser<Node<S>, NoFieldReferences, List<Node<S>>> {
     return { input ->


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER-IF-ANY>

  eg. fix(type-hint): infer type of a constant for type checking INTELLIJ-1111
-->

## Description
This PR adds support for parsing, inspecting and autocompleting in a group stage written using `Aggregation.group` and chained `GroupOperation`s using `sum`, `avg`, `first`, `last`, `max`, `min`, `push` and `addToSet`.

<!--- Describe your changes in detail so reviewers have enough content on what this PR aims to achieve -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist

- [ ] New tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
- [ ] Changelog is updated accordingly.
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement).

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->