### PR TITLE
feat: adds support for parsing `Sort` objects attached to `Query` objects in spring data mongodb INTELLIJ-199

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ MongoDB plugin for IntelliJ IDEA.
 ## [Unreleased]
 
 ### Added
+* [INTELLIJ-199](https://jira.mongodb.org/browse/INTELLIJ-199) Add support for parsing, inspecting and autocompleting in method call used for chaining a `Sort` object on top of a Criteria chain in Spring data MongoDB using `Query.with()` call.
 * [INTELLIJ-197](https://jira.mongodb.org/browse/INTELLIJ-197) Add support for generating shell syntax for $group stage and supported accumulators when running queries.
 * [INTELLIJ-198](https://jira.mongodb.org/browse/INTELLIJ-198) New modal to provide default values when generating queries with unknown runtime expressions.
 * [INTELLIJ-175](https://jira.mongodb.org/browse/INTELLIJ-175) Add support for parsing, inspecting and autocompleting in a group stage written using `Aggregation.group` and chained `GroupOperation`s using `sum`, `avg`, `first`, `last`, `max`, `min`, `push` and `addToSet`.

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/SpringCriteriaCompletionContributorTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/SpringCriteriaCompletionContributorTest.kt
@@ -109,6 +109,58 @@ record Entity() {}
         setup = DefaultSetup.SPRING_DATA,
         value = """
     public List<Book> allReleasedBooks() {
+        return template.query(Book.class).matching(
+            Query.query(
+                where("released").is(true)
+            ).with(
+                Sort.by("<caret>"
+    }
+        """,
+    )
+    fun `should autocomplete fields from the current namespace in a chained sort`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDatabase("myDatabase")
+        fixture.specifyDialect(SpringCriteriaDialect)
+
+        val namespace = Namespace("myDatabase", "book")
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(GetCollectionSchema.Slice(namespace)))
+        ).thenReturn(
+            GetCollectionSchema(
+                CollectionSchema(
+                    namespace,
+                    BsonObject(
+                        mapOf(
+                            "myField" to BsonString,
+                            "myField2" to BsonString,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField"
+            },
+        )
+
+        assertTrue(
+            elements.containsElements {
+                it.lookupString == "myField2"
+            },
+        )
+    }
+
+    @ParsingTest(
+        setup = DefaultSetup.SPRING_DATA,
+        value = """
+    public List<Book> allReleasedBooks() {
         return template.aggregate(Aggregation.newAggregation(), "<caret>"
     }
         """,

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/impl/SpringCriteriaFieldCheckLinterInspectionTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/impl/SpringCriteriaFieldCheckLinterInspectionTest.kt
@@ -137,6 +137,23 @@ class SpringCriteriaFieldCheckLinterInspectionTest {
         );
     }
     
+    public void allReleasedBooksSorted() {
+        template.find(
+                query(
+                    where(
+                        <warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">"released"</warning>
+                    ).is(true)
+                ).with(
+                    Sort.by(
+                        <warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">"released"</warning>
+                    )
+                ).with(
+                    Sort.by(Sort.Direction.DESC, <warning descr="Field \"released\" does not exist in collection \"bad_db.book\"">"released"</warning>)
+                ),
+                Book.class
+        );
+    }
+    
     String releasedFromMethodCall() {
         return "released";
     }

--- a/packages/jetbrains-plugin/src/test/resources/project-fixtures/basic-java-project-with-mongodb/src/main/java/alt/mongodb/springcriteria/BookRepository.java
+++ b/packages/jetbrains-plugin/src/test/resources/project-fixtures/basic-java-project-with-mongodb/src/main/java/alt/mongodb/springcriteria/BookRepository.java
@@ -1,8 +1,10 @@
 package alt.mongodb.springcriteria;
 
+import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Query;
 
 import java.util.List;
 
@@ -19,7 +21,13 @@ class BookRepository {
     }
 
     public List<Book> allReleasedBooks() {
-        return template.query(Book.class).matching(where("released").is(true)).all();
+        return template.query(Book.class).matching(
+            Query.query(
+                where("released").is(true)
+            ).with(
+                Sort.by("year", "title")
+            )
+        )
     }
 
     public List<Book> allReleasedBooksAgg() {

--- a/packages/mongodb-dialects/spring-criteria/src/main/kotlin/com/mongodb/jbplugin/dialects/springcriteria/QuerySortParser.kt
+++ b/packages/mongodb-dialects/spring-criteria/src/main/kotlin/com/mongodb/jbplugin/dialects/springcriteria/QuerySortParser.kt
@@ -1,0 +1,66 @@
+package com.mongodb.jbplugin.dialects.springcriteria
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiExpression
+import com.mongodb.jbplugin.dialects.javadriver.glossary.fuzzyResolveMethod
+import com.mongodb.jbplugin.dialects.javadriver.glossary.resolveToMethodCallExpression
+import com.mongodb.jbplugin.dialects.springcriteria.aggregationstageparsers.SortStageParser
+import com.mongodb.jbplugin.dialects.springcriteria.aggregationstageparsers.gatherChainedCalls
+import com.mongodb.jbplugin.dialects.springcriteria.aggregationstageparsers.isSortObject
+import com.mongodb.jbplugin.dialects.springcriteria.aggregationstageparsers.resolveToSortCreationCall
+import com.mongodb.jbplugin.mql.Node
+
+private const val QUERY_FQN = "org.springframework.data.mongodb.core.query.Query"
+
+/**
+ * Responsible for parsing `Sort` objects chained on `Query` objects.
+ */
+class QuerySortParser {
+    fun parse(queryObjectExpression: PsiExpression?): List<Node<PsiElement>> {
+        val queryMethodCallExpression =
+            queryObjectExpression?.resolveToMethodCallExpression { _, method ->
+                // We will resolve any method that is from Query class and then later filter
+                // only for the sort method in the chain of calls
+                method.containingClass?.qualifiedName == QUERY_FQN
+            } ?: return emptyList()
+
+        return queryMethodCallExpression.gatherChainedCalls().flatMap { chainedCallExpression ->
+            val chainedCall = chainedCallExpression.fuzzyResolveMethod()
+            when (chainedCall?.name) {
+                // Query.of(Query.from()) - need to grab the argument of method and resolve sort
+                // from there
+                "of" -> {
+                    val childQueryObjectExpression = chainedCallExpression.argumentList.expressions.getOrNull(
+                        0
+                    )
+                    if (childQueryObjectExpression != null) {
+                        parse(childQueryObjectExpression)
+                    } else {
+                        emptyList()
+                    }
+                }
+                // Query.query(...).with(sortObject) - This is our Sort attaching call
+                "with" -> {
+                    val maybeSortObjectExpression = chainedCallExpression.argumentList.expressions.getOrNull(
+                        0
+                    )
+                    if (maybeSortObjectExpression?.isSortObject() == true) {
+                        val sortCreationMethodCall =
+                            maybeSortObjectExpression.resolveToSortCreationCall()
+                                ?: return@flatMap emptyList()
+
+                        SortStageParser.parseSortObjectArgument(
+                            sortCreationMethodCall = sortCreationMethodCall,
+                            // There is no parent chain just yet
+                            directionForcedFromParentChain = null,
+                            reverseCountForcedFromParentChain = 0
+                        )
+                    } else {
+                        emptyList()
+                    }
+                }
+                else -> emptyList()
+            }
+        }
+    }
+}

--- a/packages/mongodb-dialects/spring-criteria/src/main/kotlin/com/mongodb/jbplugin/dialects/springcriteria/SpringCriteriaDialectParser.kt
+++ b/packages/mongodb-dialects/spring-criteria/src/main/kotlin/com/mongodb/jbplugin/dialects/springcriteria/SpringCriteriaDialectParser.kt
@@ -394,7 +394,7 @@ object SpringCriteriaDialectParser : DialectParser<PsiElement> {
         }
 
         // clean up, we might be in a query() call
-        if (valueFilterMethod.name == "query") {
+        if (valueFilterMethod.name == "query" || valueFilterMethod.name == "of") {
             return parseFilterRecursively(valueMethodCall.argumentList.expressions.getOrNull(0))
         }
 

--- a/packages/mongodb-dialects/spring-criteria/src/main/kotlin/com/mongodb/jbplugin/dialects/springcriteria/aggregationstageparsers/SortStageParser.kt
+++ b/packages/mongodb-dialects/spring-criteria/src/main/kotlin/com/mongodb/jbplugin/dialects/springcriteria/aggregationstageparsers/SortStageParser.kt
@@ -173,7 +173,7 @@ class SortStageParser : StageParser {
                             ?: return@flatMapIndexed emptyList<Node<PsiElement>>()
 
                     return@flatMapIndexed parseSortObjectArgument(
-                        sortCreationMethodCall,
+                        sortCreationMethodCallPassedToAnd,
                         forcedDirection,
                         reverseCount
                     )

--- a/packages/mongodb-dialects/spring-criteria/src/test/kotlin/com/mongodb/jbplugin/dialects/springcriteria/SpringCriteriaDialectParserTest.kt
+++ b/packages/mongodb-dialects/spring-criteria/src/test/kotlin/com/mongodb/jbplugin/dialects/springcriteria/SpringCriteriaDialectParserTest.kt
@@ -75,7 +75,8 @@ class Repository {
     @ParsingTest(
         fileName = "Book.java",
         """
-import org.springframework.data.domain.Sort;import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
@@ -108,7 +109,6 @@ class Repository {
         psiFile: PsiFile
     ) {
         val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
-        println(SpringCriteriaDialectParser.parse(query))
         SpringCriteriaDialectParser.parse(query).assert(IsCommand.CommandType.FIND_MANY) {
             component<HasSourceDialect> {
                 assertEquals(HasSourceDialect.DialectName.SPRING_CRITERIA, name)
@@ -139,6 +139,98 @@ class Repository {
             }
 
             sortN(1, Name.DESCENDING) {
+                field<HasFieldReference.FromSchema<PsiElement>> {
+                    assertEquals("ratings", fieldName)
+                }
+                value<HasValueReference.Inferred<PsiElement>> {
+                    assertEquals(BsonInt32, type)
+                    assertEquals(-1, value)
+                }
+            }
+        }
+    }
+
+    @ParsingTest(
+        fileName = "Book.java",
+        """
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Document
+record Book() {}
+
+class Repository {
+    private final MongoTemplate template;
+    
+    public Repository(MongoTemplate template) {
+        this.template = template;
+    }
+    
+    public List<Book> allReleasedBooks() {
+        return template.query(Book.class).matching(
+            Query.of(
+                Query.query(
+                    where("released").is(true)
+                ).with(Sort.by(Sort.Direction.DESC, "year", "ratings"))
+                .with(Sort.by("title"))
+            )
+        ).all();
+    }
+}
+        """
+    )
+    fun `extracts a simple criteria query built with Query#of even when chained with Sort using #with`(
+        psiFile: PsiFile
+    ) {
+        val query = psiFile.getQueryAtMethod("Repository", "allReleasedBooks")
+        println(SpringCriteriaDialectParser.parse(query))
+        SpringCriteriaDialectParser.parse(query).assert(IsCommand.CommandType.FIND_MANY) {
+            component<HasSourceDialect> {
+                assertEquals(HasSourceDialect.DialectName.SPRING_CRITERIA, name)
+            }
+
+            collection<HasCollectionReference.OnlyCollection<PsiElement>> {
+                assertEquals("book", collection)
+            }
+
+            filterN(0, Name.EQ) {
+                field<HasFieldReference.FromSchema<PsiElement>> {
+                    assertEquals("released", fieldName)
+                }
+                value<HasValueReference.Constant<PsiElement>> {
+                    assertEquals(BsonAnyOf(BsonNull, BsonBoolean), type)
+                    assertEquals(true, value)
+                }
+            }
+
+            sortN(0, Name.ASCENDING) {
+                field<HasFieldReference.FromSchema<PsiElement>> {
+                    assertEquals("title", fieldName)
+                }
+                value<HasValueReference.Inferred<PsiElement>> {
+                    assertEquals(BsonInt32, type)
+                    assertEquals(1, value)
+                }
+            }
+
+            sortN(1, Name.DESCENDING) {
+                field<HasFieldReference.FromSchema<PsiElement>> {
+                    assertEquals("year", fieldName)
+                }
+                value<HasValueReference.Inferred<PsiElement>> {
+                    assertEquals(BsonInt32, type)
+                    assertEquals(-1, value)
+                }
+            }
+
+            sortN(2, Name.DESCENDING) {
                 field<HasFieldReference.FromSchema<PsiElement>> {
                     assertEquals("ratings", fieldName)
                 }


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER-IF-ANY>

  eg. fix(type-hint): infer type of a constant for type checking INTELLIJ-1111
-->

## Description
This PR adds support for parsing `Sort` objects attached to `Query` objects in spring data mongodb using `.with` call.

We have re-used the entire `Sort` object parsing logic from `SortStageParser` which is why there is a little refactor over there (without any logic changes) and on top of that built a `QuerySortParser` to handle the specific cases of writing a query expression.

Test case coverage includes:
- parsing test
- field inspection test
- autocomplete test
- query generation test which was already present

<!--- Describe your changes in detail so reviewers have enough content on what this PR aims to achieve -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist

- [x] New tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
- [x] Changelog is updated accordingly.
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement).

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->