### PR TITLE
feat: Introduce a new configurable plugin setting `sampleSize` for configuring documents fetched for collection schema analysis INTELLIJ-211

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ MongoDB plugin for IntelliJ IDEA.
 ## [Unreleased]
 
 ### Added
+* [INTELLIJ-211](https://jira.mongodb.org/browse/INTELLIJ-211) Introduce a new configurable plugin setting `sampleSize` which dictates how many documents to be fetched and used for analysing a collection's schema.
 * [INTELLIJ-199](https://jira.mongodb.org/browse/INTELLIJ-199) Add support for parsing, inspecting and autocompleting in method call used for chaining a `Sort` object on top of a Criteria chain in Spring data MongoDB using `Query.with()` call.
 * [INTELLIJ-197](https://jira.mongodb.org/browse/INTELLIJ-197) Add support for generating shell syntax for $group stage and supported accumulators when running queries.
 * [INTELLIJ-198](https://jira.mongodb.org/browse/INTELLIJ-198) New modal to provide default values when generating queries with unknown runtime expressions.

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/autocomplete/MongoDbCompletionContributor.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/autocomplete/MongoDbCompletionContributor.kt
@@ -39,6 +39,7 @@ import com.mongodb.jbplugin.mql.components.HasCollectionReference
 import com.mongodb.jbplugin.mql.components.IsCommand
 import com.mongodb.jbplugin.mql.components.IsCommand.CommandType
 import com.mongodb.jbplugin.observability.probe.AutocompleteSuggestionAcceptedProbe
+import com.mongodb.jbplugin.settings.PluginSettings
 import kotlin.collections.emptyList
 import kotlin.collections.map
 
@@ -138,12 +139,14 @@ internal object Field {
             }
 
             val readModelProvider by parameters.originalFile.project.service<DataGripBasedReadModelProvider>()
+            val pluginSettings by parameters.originalFile.project.service<PluginSettings>()
 
             val completions =
                 Autocompletion.autocompleteFields(
                     dataSource,
                     readModelProvider,
                     Namespace(database, collection),
+                    pluginSettings.sampleSize
                 ) as? AutocompletionResult.Successful
 
             val lookupEntries = completions?.entries?.map {

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/inspections/impl/FieldCheckInspectionBridge.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/inspections/impl/FieldCheckInspectionBridge.kt
@@ -23,6 +23,7 @@ import com.mongodb.jbplugin.mql.Node
 import com.mongodb.jbplugin.mql.components.HasCollectionReference
 import com.mongodb.jbplugin.observability.TelemetryEvent
 import com.mongodb.jbplugin.observability.probe.InspectionStatusChangedProbe
+import com.mongodb.jbplugin.settings.PluginSettings
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.runBlocking
 
@@ -67,12 +68,14 @@ internal object FieldCheckLinterInspection : MongoDbInspection {
         }
 
         val readModelProvider by query.source.project.service<DataGripBasedReadModelProvider>()
+        val pluginSettings by query.source.project.service<PluginSettings>()
 
         val result = runBlocking {
             FieldCheckingLinter.lintQuery(
                 dataSource,
                 readModelProvider,
                 query,
+                pluginSettings.sampleSize
             )
         }
 

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/settings/PluginSettings.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/settings/PluginSettings.kt
@@ -26,6 +26,8 @@ class PluginSettingsStateComponent : SimplePersistentStateComponent<PluginSettin
     PluginSettings()
 )
 
+internal const val DEFAULT_SAMPLE_SIZE = 50
+
 /**
  * The settings themselves. They are tracked, so any change on the settings properties will be eventually
  * persisted by IntelliJ. To access the settings, use the pluginSetting provider. For example,
@@ -49,6 +51,7 @@ class PluginSettings : BaseState(), Serializable {
     var isTelemetryEnabled by property(true)
     var hasTelemetryOptOutputNotificationBeenShown by property(false)
     var isFullExplainPlanEnabled by property(false)
+    var sampleSize by property(DEFAULT_SAMPLE_SIZE)
 }
 
 class SettingsDelegate<T>(private val settingProp: KMutableProperty0<T>) {

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/settings/PluginSettingsConfigurable.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/settings/PluginSettingsConfigurable.kt
@@ -116,6 +116,7 @@ private class PluginSettingsComponent {
         root.accessibleContext.accessibleName = "MongoDB Settings"
         isTelemetryEnabledCheckBox.accessibleContext.accessibleName = "MongoDB Enable Telemetry"
         enableFullExplainPlan.accessibleContext.accessibleName = "MongoDB Enable Full Explain Plan"
+        sampleSize.accessibleContext.accessibleName = "MongoDB Sample Size"
     }
 
     fun getSampleSizeField(): JComponent {

--- a/packages/jetbrains-plugin/src/main/resources/messages/SettingsBundle.properties
+++ b/packages/jetbrains-plugin/src/main/resources/messages/SettingsBundle.properties
@@ -1,1 +1,3 @@
 settings.display-name=MongoDB
+settings.sample-size.label=Sample size (documents)
+settings.sample-size.sub-label=Number of documents retrieved to analyze the collection schema.

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/fixtures/components/MongoDbSettingsFixture.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/fixtures/components/MongoDbSettingsFixture.kt
@@ -11,6 +11,7 @@ package com.mongodb.jbplugin.fixtures.components
 import com.intellij.remoterobot.RemoteRobot
 import com.intellij.remoterobot.data.RemoteComponent
 import com.intellij.remoterobot.fixtures.*
+import com.intellij.remoterobot.search.locators.byXpath
 import com.mongodb.jbplugin.fixtures.findVisible
 import com.mongodb.jbplugin.fixtures.openSettingsAtSection
 
@@ -47,6 +48,12 @@ class MongoDbSettingsFixture(
     val analyzeQueryPerformanceButton by lazy {
         findAll<JButtonFixture>().find { it.text == "Analyze Query Performance" }
             ?: throw NoSuchElementException()
+    }
+
+    val sampleSizeField by lazy {
+        find<JTextFieldFixture>(
+            byXpath("//div[@class='JFormattedTextField' and @accessiblename='MongoDB Sample Size']")
+        )
     }
 
     val ok by lazy {

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/settings/SettingsUiTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/settings/SettingsUiTest.kt
@@ -6,6 +6,7 @@ import com.mongodb.jbplugin.fixtures.UiTest
 import com.mongodb.jbplugin.fixtures.components.openBrowserSettings
 import com.mongodb.jbplugin.fixtures.components.openSettings
 import com.mongodb.jbplugin.fixtures.components.useSetting
+import com.mongodb.jbplugin.fixtures.eventually
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
@@ -80,5 +81,27 @@ class SettingsUiTest {
             "https://www.mongodb.com/docs/manual/tutorial/evaluate-operation-performance/",
             lastBrowserUrl
         )
+    }
+
+    @Test
+    @RequiresProject("basic-java-project-with-mongodb")
+    fun `allows adjusting sample size with a valid value`(remoteRobot: RemoteRobot) {
+        remoteRobot.openBrowserSettings().run {
+            useFakeBrowser()
+        }
+
+        eventually {
+            val settings = remoteRobot.openSettings()
+            assertEquals("50", settings.sampleSizeField.text)
+            settings.sampleSizeField.text = "10"
+            settings.ok.click()
+        }
+
+        eventually {
+            val settings = remoteRobot.openSettings()
+            assertEquals("10", settings.sampleSizeField.text)
+            settings.sampleSizeField.text = "50"
+            settings.ok.click()
+        }
     }
 }

--- a/packages/mongodb-access-adapter/src/main/kotlin/com/mongodb/jbplugin/accessadapter/slice/GetCollectionSchema.kt
+++ b/packages/mongodb-access-adapter/src/main/kotlin/com/mongodb/jbplugin/accessadapter/slice/GetCollectionSchema.kt
@@ -13,11 +13,9 @@ import org.bson.Document
 data class GetCollectionSchema(
     val schema: CollectionSchema,
 ) {
-    /**
-     * @param namespace
-     */
     data class Slice(
         private val namespace: Namespace,
+        private val documentsSampleSize: Int,
     ) : com.mongodb.jbplugin.accessadapter.Slice<GetCollectionSchema> {
         override val id = "${javaClass.canonicalName}::$namespace"
 
@@ -35,7 +33,7 @@ data class GetCollectionSchema(
                 namespace,
                 Filters.empty(),
                 Document::class,
-                limit = 50
+                limit = documentsSampleSize
             )
             // we need to generate the schema from these docs
             val sampleSchemas = sampleSomeDocs.map(this::recursivelyBuildSchema)

--- a/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/autocomplete/Autocompletion.kt
+++ b/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/autocomplete/Autocompletion.kt
@@ -117,12 +117,14 @@ object Autocompletion {
         dataSource: D,
         readModelProvider: MongoDbReadModelProvider<D>,
         namespace: Namespace,
+        documentsSampleSize: Int,
     ): AutocompletionResult {
         val schema = runCatching {
-            readModelProvider.slice(dataSource, GetCollectionSchema.Slice(namespace)).schema
-        }
-            .getOrNull()
-        schema ?: return AutocompletionResult.NoModel(namespace)
+            readModelProvider.slice(
+                dataSource,
+                GetCollectionSchema.Slice(namespace, documentsSampleSize)
+            ).schema
+        }.getOrNull() ?: return AutocompletionResult.NoModel(namespace)
 
         val entries =
             schema.allFieldNamesQualified().map {

--- a/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/FieldCheckingLinter.kt
+++ b/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/FieldCheckingLinter.kt
@@ -90,13 +90,14 @@ object FieldCheckingLinter {
         dataSource: D,
         readModelProvider: MongoDbReadModelProvider<D>,
         query: Node<S>,
+        documentsSampleSize: Int,
     ): FieldCheckResult<S> {
         val querySchema = knownCollection<S>()
             .filter { it.namespace.isValid }
             .map {
                 readModelProvider.slice(
                     dataSource,
-                    GetCollectionSchema.Slice(it.namespace)
+                    GetCollectionSchema.Slice(it.namespace, documentsSampleSize)
                 ).schema
             }.parse(query)
 

--- a/packages/mongodb-mql-engines/src/test/kotlin/com/mongodb/jbplugin/autocomplete/AutocompletionTest.kt
+++ b/packages/mongodb-mql-engines/src/test/kotlin/com/mongodb/jbplugin/autocomplete/AutocompletionTest.kt
@@ -90,7 +90,7 @@ class AutocompletionTest {
     fun `returns the list of fields for sample documents`() {
         val readModelProvider = mock<MongoDbReadModelProvider<Any?>>()
         val namespace = Namespace("myDb", "myColl")
-        val slice = GetCollectionSchema.Slice(namespace)
+        val slice = GetCollectionSchema.Slice(namespace, 50)
 
         `when`(readModelProvider.slice(null, slice)).thenReturn(
             GetCollectionSchema(
@@ -110,7 +110,8 @@ class AutocompletionTest {
             autocompleteFields(
                 null,
                 readModelProvider,
-                namespace
+                namespace,
+                50
             ) as AutocompletionResult.Successful
 
         assertEquals(

--- a/packages/mongodb-mql-engines/src/test/kotlin/com/mongodb/jbplugin/linting/FieldCheckingLinterTest.kt
+++ b/packages/mongodb-mql-engines/src/test/kotlin/com/mongodb/jbplugin/linting/FieldCheckingLinterTest.kt
@@ -72,6 +72,7 @@ class FieldCheckingLinterTest {
                         ),
                     ),
                 ),
+                50,
             )
 
         assertEquals(1, result.warnings.size)
@@ -135,6 +136,7 @@ class FieldCheckingLinterTest {
                         ),
                     ),
                 ),
+                50,
             )
 
         assertEquals(1, result.warnings.size)
@@ -197,6 +199,7 @@ class FieldCheckingLinterTest {
                         ),
                     ),
                 ),
+                50,
             )
 
         assertEquals(1, result.warnings.size)
@@ -251,6 +254,7 @@ class FieldCheckingLinterTest {
                         ),
                     ),
                 ),
+                50,
             )
 
         assertEquals(1, result.warnings.size)
@@ -326,6 +330,7 @@ class FieldCheckingLinterTest {
                         )
                     ),
                 ),
+                50,
             )
 
         assertEquals(1, result.warnings.size)
@@ -397,6 +402,7 @@ class FieldCheckingLinterTest {
                         )
                     ),
                 ),
+                50,
             )
 
         assertEquals(1, result.warnings.size)
@@ -468,6 +474,7 @@ class FieldCheckingLinterTest {
                         )
                     ),
                 ),
+                50,
             )
 
         assertEquals(1, result.warnings.size)
@@ -539,6 +546,7 @@ class FieldCheckingLinterTest {
                         )
                     ),
                 ),
+                50,
             )
 
         assertEquals(1, result.warnings.size)
@@ -610,6 +618,7 @@ class FieldCheckingLinterTest {
                         )
                     ),
                 ),
+                50,
             )
 
         assertEquals(0, result.warnings.size)
@@ -662,6 +671,7 @@ class FieldCheckingLinterTest {
                         )
                     ),
                 ),
+                50,
             )
 
         assertEquals(1, result.warnings.size)


### PR DESCRIPTION
sampleSize is the number of documents retrieved to be used as sample for
analysing the schema of a collection. Default value is 50.<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER-IF-ANY>

  eg. fix(type-hint): infer type of a constant for type checking INTELLIJ-1111
-->

## Description
This PR introduces a new configurable plugin setting `sampleSize` which dictates how many documents will be fetched and used for analysing a collection's schema.

<!--- Describe your changes in detail so reviewers have enough content on what this PR aims to achieve -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist

- [ ] New tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
- [ ] Changelog is updated accordingly.
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement).

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->sampleSize is the number of documents retrieved to be used as sample for
analysing the schema of a collection. Default value is 50.