### PR TITLE
fix: add timezone indicator to date formatting in RunQueryModal INTELLIJ-288

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ MongoDB plugin for IntelliJ IDEA.
 ### Removed
 
 ### Fixed
+* [INTELLIJ-288](https://jira.mongodb.org/browse/INTELLIJ-288): Add timezone indicator to sample date formatting in RunQueryModal
 * [INTELLIJ-236](https://jira.mongodb.org/browse/INTELLIJ-236): Do not fail if we can't infer the cardinality of an empty BsonAnyOf
 * [INTELLIJ-235](https://jira.mongodb.org/browse/INTELLIJ-235): Detect .iterator queries written in the Java Driver.
 * [INTELLIJ-231](https://jira.mongodb.org/browse/INTELLIJ-231): Gracefully fail if the JVM does not give us access to plugin metadata.

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/codeActions/impl/runQuery/RunQueryModal.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/codeActions/impl/runQuery/RunQueryModal.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.runBlocking
 import org.bson.types.ObjectId
 import java.awt.event.ActionEvent
 import java.time.LocalDateTime
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.*
 import javax.swing.Action
@@ -250,7 +251,7 @@ class RunQueryModal(
             BsonDate -> QueryContext.LocalVariable(
                 BsonDate,
                 parseOrAsIs(value) {
-                    DATE_FORMATTER.parse(it)
+                    DATE_PARSER.parse(it)
                 }
             )
             BsonObjectId -> QueryContext.LocalVariable(BsonObjectId, parseOrAsIs(value, ::ObjectId))
@@ -264,9 +265,10 @@ class RunQueryModal(
     }
 
     companion object {
-        private val DATE_FORMATTER = DateTimeFormatter.ISO_DATE_TIME
+        private val DATE_FORMATTER = DateTimeFormatter.ISO_INSTANT
+        private val DATE_PARSER = DateTimeFormatter.ISO_DATE_TIME
 
-        internal fun sampleDateTime() = DATE_FORMATTER.format(LocalDateTime.now())
+        internal fun sampleDateTime() = DATE_FORMATTER.format(LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant())
         internal fun sampleObjectId() = ObjectId().toHexString()
         internal fun sampleUuid() = UUID.randomUUID().toString()
     }

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/codeActions/impl/runQuery/RunQueryModalTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/codeActions/impl/runQuery/RunQueryModalTest.kt
@@ -22,6 +22,7 @@ import org.assertj.swing.exception.ComponentLookupException
 import org.assertj.swing.fixture.FrameFixture
 import org.bson.types.ObjectId
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
@@ -285,6 +286,17 @@ class RunQueryModalTest {
                 boolInput.type
             )
         }
+    }
+
+    @Test
+    fun `formats the sample date with timezone info`(
+        robot: Robot,
+        project: Project,
+        coroutineScope: CoroutineScope
+    ) {
+        assertTrue(
+            RunQueryModal.sampleDateTime().endsWith("Z")
+        )
     }
 
     companion object {


### PR DESCRIPTION
!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER-IF-ANY>

  eg. fix(type-hint): infer type of a constant for type checking INTELLIJ-1111
-->

## Description

<!--- Describe your changes in detail so reviewers have enough content on what this PR aims to achieve -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist

- [ ] New tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
- [ ] Changelog is updated accordingly.
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement).

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->- Use ISO_INSTANT formatter for date formatting to include 'Z' timezone
  indicator
- Keep ISO_DATE_TIME formatter for parsing to be flexible with inputs