### PR TITLE
fix: correctly highlight problematic sources instead of entire query INTELLIJ-292

### DIFF
--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/analysisScope/AnalysisScopeTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/analysisScope/AnalysisScopeTest.kt
@@ -198,6 +198,7 @@ class AnalysisScopeTest {
                 source,
                 emptyList()
             ),
+            source,
             "Some",
             emptyList(),
             Inspection.NotUsingIndex
@@ -207,7 +208,7 @@ class AnalysisScopeTest {
     }
 
     private fun insightOnQuery(query: Node<PsiElement>): QueryInsight<PsiElement, *> {
-        return QueryInsight(query, "Some", emptyList(), Inspection.NotUsingIndex)
+        return QueryInsight(query, query.source, "Some", emptyList(), Inspection.NotUsingIndex)
     }
 
     private fun queryWithHash(hash: Int): Node<PsiElement> {

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/insightAction/ChooseConnectionInsightActionTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/insightAction/ChooseConnectionInsightActionTest.kt
@@ -37,9 +37,14 @@ class ChooseConnectionInsightActionTest {
             }
         }
 
+        val query = project.aQuery()
         runBlocking {
             ChooseConnectionInsightAction().apply(
-                QueryInsight.nonExistentDatabase(project.aQuery(), "db")
+                QueryInsight.nonExistentDatabase(
+                    query,
+                    query.source,
+                    "db"
+                )
             )
         }
 

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/insightAction/RunQueryInsightActionTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/insightAction/RunQueryInsightActionTest.kt
@@ -31,7 +31,7 @@ class RunQueryInsightActionTest {
         val insightAction = RunQueryInsightAction(coroutineScope, probe, consoleEditor)
         val query = project.aQuery()
 
-        insightAction.apply(QueryInsight.nonExistingField(query, "anyfield"))
+        insightAction.apply(QueryInsight.nonExistingField(query, query.source, "anyfield"))
 
         verify(probe).queryRunRequested(query, Console.EXISTING, TelemetryEvent.QueryRunEvent.TriggerLocation.SIDE_PANEL)
     }
@@ -50,7 +50,7 @@ class RunQueryInsightActionTest {
         val insightAction = RunQueryInsightAction(coroutineScope, probe, consoleEditor)
         val query = project.aQuery()
 
-        insightAction.apply(QueryInsight.nonExistingField(query, "anyfield"))
+        insightAction.apply(QueryInsight.nonExistingField(query, query.source, "anyfield"))
 
         verify(consoleEditor).openConsoleForDataSource(project, dataSource)
     }

--- a/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/QueryInsight.kt
+++ b/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/QueryInsight.kt
@@ -97,6 +97,7 @@ sealed interface Inspection {
 
 data class QueryInsight<S, I : Inspection>(
     val query: Node<S>,
+    val source: S,
     val description: String,
     val descriptionArguments: List<String>,
     val inspection: I
@@ -105,6 +106,7 @@ data class QueryInsight<S, I : Inspection>(
         fun <S> notUsingIndex(query: Node<S>): QueryInsight<S, NotUsingIndex> {
             return QueryInsight(
                 query = query,
+                source = query.source,
                 description = "insight.not-using-index",
                 descriptionArguments = emptyList(),
                 inspection = NotUsingIndex
@@ -116,6 +118,7 @@ data class QueryInsight<S, I : Inspection>(
         ): QueryInsight<S, NotUsingIndexEffectively> {
             return QueryInsight(
                 query = query,
+                source = query.source,
                 description = "insight.not-using-index-effectively",
                 descriptionArguments = emptyList(),
                 inspection = NotUsingIndexEffectively
@@ -124,10 +127,12 @@ data class QueryInsight<S, I : Inspection>(
 
         fun <S> nonExistingField(
             query: Node<S>,
+            source: S,
             field: String
         ): QueryInsight<S, FieldDoesNotExist> {
             return QueryInsight(
                 query = query,
+                source = source,
                 description = "insight.field-does-not-exist",
                 descriptionArguments = listOf(field),
                 inspection = FieldDoesNotExist
@@ -136,12 +141,14 @@ data class QueryInsight<S, I : Inspection>(
 
         fun <S> typeMismatch(
             query: Node<S>,
+            source: S,
             field: String,
             fieldType: String,
             valueType: String
         ): QueryInsight<S, TypeMismatch> {
             return QueryInsight(
                 query = query,
+                source = source,
                 description = "insight.type-mismatch",
                 descriptionArguments = listOf(field, fieldType, valueType),
                 inspection = TypeMismatch
@@ -150,10 +157,12 @@ data class QueryInsight<S, I : Inspection>(
 
         fun <S> nonExistentDatabase(
             query: Node<S>,
+            source: S,
             database: String
         ): QueryInsight<S, DatabaseDoesNotExist> {
             return QueryInsight(
                 query = query,
+                source = source,
                 description = "insight.database-does-not-exist",
                 descriptionArguments = listOf(database),
                 inspection = DatabaseDoesNotExist
@@ -162,11 +171,13 @@ data class QueryInsight<S, I : Inspection>(
 
         fun <S> nonExistentCollection(
             query: Node<S>,
+            source: S,
             collection: String,
             database: String,
         ): QueryInsight<S, CollectionDoesNotExist> {
             return QueryInsight(
                 query = query,
+                source = source,
                 description = "insight.collection-does-not-exist",
                 descriptionArguments = listOf(collection, database),
                 inspection = CollectionDoesNotExist
@@ -178,6 +189,9 @@ data class QueryInsight<S, I : Inspection>(
         ): QueryInsight<S, NoDatabaseInferred> {
             return QueryInsight(
                 query = query,
+                // Ideally we should be attaching the insight to whichever database reference we
+                // can find but our current NamespaceExtractor strips out that information.
+                source = query.source,
                 description = "insight.no-database-inferred",
                 descriptionArguments = listOf(),
                 inspection = NoDatabaseInferred
@@ -189,6 +203,9 @@ data class QueryInsight<S, I : Inspection>(
         ): QueryInsight<S, NoCollectionSpecified> {
             return QueryInsight(
                 query = query,
+                // Ideally we should be attaching the insight to whichever collection reference we
+                // can find but our current NamespaceExtractor strips out that information.
+                source = query.source,
                 description = "insight.no-collection-specified",
                 descriptionArguments = listOf(),
                 inspection = NoCollectionSpecified

--- a/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/correctness/FieldDoesNotExistInspection.kt
+++ b/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/correctness/FieldDoesNotExistInspection.kt
@@ -52,8 +52,14 @@ class FieldDoesNotExistInspection<D> : QueryInspection<
 
                 allFields.filter {
                     collectionSchema.typeOf(it.fieldName) == BsonNull
-                }.forEach {
-                    holder.register(QueryInsight.nonExistingField(query, it.fieldName))
+                }.forEach { field ->
+                    holder.register(
+                        QueryInsight.nonExistingField(
+                            query = query,
+                            source = field.source,
+                            field = field.fieldName
+                        )
+                    )
                 }
             }
             else -> {}

--- a/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/correctness/TypeMismatchInspection.kt
+++ b/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/correctness/TypeMismatchInspection.kt
@@ -60,12 +60,20 @@ class TypeMismatchInspection<D> : QueryInspection<
 
                 allFieldsAndValues.filter {
                     it.second != null && isCandidateForWarning(collectionSchema, it)
-                }.forEach {
-                    val fieldName = it.first.fieldName
+                }.forEach { (fieldRef, parsedValueRef) ->
+                    val fieldName = fieldRef.fieldName
                     val fieldType = settings.typeFormatter(collectionSchema.typeOf(fieldName))
-                    val valueType = settings.typeFormatter(it.second!!.type)
+                    val valueType = settings.typeFormatter(parsedValueRef!!.type)
 
-                    holder.register(QueryInsight.typeMismatch(query, fieldName, fieldType, valueType))
+                    holder.register(
+                        QueryInsight.typeMismatch(
+                            query = query,
+                            source = parsedValueRef.source,
+                            field = fieldName,
+                            fieldType = fieldType,
+                            valueType = valueType
+                        )
+                    )
                 }
             }
             else -> {}

--- a/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/environmentmismatch/CollectionDoesNotExistInspection.kt
+++ b/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/environmentmismatch/CollectionDoesNotExistInspection.kt
@@ -46,6 +46,7 @@ class CollectionDoesNotExistInspection<D> : QueryInspection<
                 holder.register(
                     QueryInsight.nonExistentCollection(
                         query = query,
+                        source = parsingResult.value.collectionSource,
                         collection = parsingResult.value.namespace.collection,
                         database = parsingResult.value.namespace.database,
                     )

--- a/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/environmentmismatch/DatabaseDoesNotExistInspection.kt
+++ b/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/environmentmismatch/DatabaseDoesNotExistInspection.kt
@@ -42,10 +42,12 @@ class DatabaseDoesNotExistInspection<D> : QueryInspection<
 
         when (parsingResult) {
             is Either.Right -> {
+                val collectionRef = parsingResult.value
                 holder.register(
                     QueryInsight.nonExistentDatabase(
-                        query,
-                        parsingResult.value.namespace.database
+                        query = query,
+                        source = collectionRef.databaseSource ?: query.source,
+                        database = collectionRef.namespace.database
                     )
                 )
             }


### PR DESCRIPTION
Additionally we make sure that we don't highlight insight sources for Performance inspections.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER-IF-ANY>

  eg. fix(type-hint): infer type of a constant for type checking INTELLIJ-1111
-->

## Description

<!--- Describe your changes in detail so reviewers have enough content on what this PR aims to achieve -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist

- [ ] New tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
- [ ] Changelog is updated accordingly.
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement).

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->