### PR TITLE
fix: fixes inspection hierarchy for inspection runs INTELLIJ-293

### DIFF
--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inlays/MongoDbQueryIndexStatusInlayTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inlays/MongoDbQueryIndexStatusInlayTest.kt
@@ -4,6 +4,8 @@ import com.intellij.codeInsight.hints.InlineInlayRenderer
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import com.mongodb.jbplugin.accessadapter.slice.ExplainPlan
 import com.mongodb.jbplugin.accessadapter.slice.ExplainQuery
+import com.mongodb.jbplugin.accessadapter.slice.ListCollections
+import com.mongodb.jbplugin.accessadapter.slice.ListDatabases
 import com.mongodb.jbplugin.dialects.javadriver.glossary.JavaDriverDialect
 import com.mongodb.jbplugin.fixtures.IntegrationTest
 import com.mongodb.jbplugin.fixtures.ParsingTest
@@ -19,6 +21,78 @@ class MongoDbQueryIndexStatusInlayTest {
     @ParsingTest(
         value = """
     public FindIterable<Document> exampleFind() {
+        client.getDatabase("myDatabase")
+                .getCollection("myCollection")
+                .find();
+    }
+        """,
+    )
+    fun `does not show any inlay when the database does not exist`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModel) = fixture.setupConnection()
+        fixture.specifyDialect(JavaDriverDialect)
+        whenever(readModel.slice(eq(dataSource), any<ListDatabases.Slice>()))
+            .thenReturn(
+                ListDatabases(
+                    listOf(ListDatabases.Database("myDatabase1"))
+                )
+            )
+
+        whenever(readModel.slice(eq(dataSource), any<ListCollections.Slice>()))
+            .thenReturn(
+                ListCollections(
+                    listOf(
+                        ListCollections.Collection("myCollection", "collection")
+                    )
+                )
+            )
+
+        whenever(readModel.slice(eq(dataSource), any<ExplainQuery.Slice<Any>>()))
+            .thenReturn(ExplainQuery(ExplainPlan.CollectionScan))
+
+        fixture.testIndexInlay()
+    }
+
+    @ParsingTest(
+        value = """
+    public FindIterable<Document> exampleFind() {
+        client.getDatabase("myDatabase")
+                .getCollection("myCollection")
+                .find();
+    }
+        """,
+    )
+    fun `does not show any inlay when the collection does not exist`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModel) = fixture.setupConnection()
+        fixture.specifyDialect(JavaDriverDialect)
+        whenever(readModel.slice(eq(dataSource), any<ListDatabases.Slice>()))
+            .thenReturn(
+                ListDatabases(
+                    listOf(ListDatabases.Database("myDatabase"))
+                )
+            )
+
+        whenever(readModel.slice(eq(dataSource), any<ListCollections.Slice>()))
+            .thenReturn(
+                ListCollections(
+                    listOf(
+                        ListCollections.Collection("myCollection1", "collection")
+                    )
+                )
+            )
+
+        whenever(readModel.slice(eq(dataSource), any<ExplainQuery.Slice<Any>>()))
+            .thenReturn(ExplainQuery(ExplainPlan.CollectionScan))
+
+        fixture.testIndexInlay()
+    }
+
+    @ParsingTest(
+        value = """
+    public FindIterable<Document> exampleFind() {
         <hint text="[<image> Collection Scan]"/>client.getDatabase("myDatabase")
                 .getCollection("myCollection")
                 .find();
@@ -30,6 +104,21 @@ class MongoDbQueryIndexStatusInlayTest {
     ) {
         val (dataSource, readModel) = fixture.setupConnection()
         fixture.specifyDialect(JavaDriverDialect)
+        whenever(readModel.slice(eq(dataSource), any<ListDatabases.Slice>()))
+            .thenReturn(
+                ListDatabases(
+                    listOf(ListDatabases.Database("myDatabase"))
+                )
+            )
+
+        whenever(readModel.slice(eq(dataSource), any<ListCollections.Slice>()))
+            .thenReturn(
+                ListCollections(
+                    listOf(
+                        ListCollections.Collection("myCollection", "collection")
+                    )
+                )
+            )
 
         whenever(readModel.slice(eq(dataSource), any<ExplainQuery.Slice<Any>>()))
             .thenReturn(ExplainQuery(ExplainPlan.CollectionScan))
@@ -52,6 +141,22 @@ class MongoDbQueryIndexStatusInlayTest {
         val (dataSource, readModel) = fixture.setupConnection()
         fixture.specifyDialect(JavaDriverDialect)
 
+        whenever(readModel.slice(eq(dataSource), any<ListDatabases.Slice>()))
+            .thenReturn(
+                ListDatabases(
+                    listOf(ListDatabases.Database("myDatabase"))
+                )
+            )
+
+        whenever(readModel.slice(eq(dataSource), any<ListCollections.Slice>()))
+            .thenReturn(
+                ListCollections(
+                    listOf(
+                        ListCollections.Collection("myCollection", "collection")
+                    )
+                )
+            )
+
         whenever(readModel.slice(eq(dataSource), any<ExplainQuery.Slice<Any>>()))
             .thenReturn(ExplainQuery(ExplainPlan.IndexScan("my_index")))
 
@@ -73,6 +178,22 @@ class MongoDbQueryIndexStatusInlayTest {
         val (dataSource, readModel) = fixture.setupConnection()
         fixture.specifyDialect(JavaDriverDialect)
 
+        whenever(readModel.slice(eq(dataSource), any<ListDatabases.Slice>()))
+            .thenReturn(
+                ListDatabases(
+                    listOf(ListDatabases.Database("myDatabase"))
+                )
+            )
+
+        whenever(readModel.slice(eq(dataSource), any<ListCollections.Slice>()))
+            .thenReturn(
+                ListCollections(
+                    listOf(
+                        ListCollections.Collection("myCollection", "collection")
+                    )
+                )
+            )
+
         whenever(readModel.slice(eq(dataSource), any<ExplainQuery.Slice<Any>>()))
             .thenReturn(ExplainQuery(ExplainPlan.IneffectiveIndexUsage("my_index")))
 
@@ -93,6 +214,22 @@ class MongoDbQueryIndexStatusInlayTest {
     ) {
         val (dataSource, readModel) = fixture.setupConnection()
         fixture.specifyDialect(JavaDriverDialect)
+
+        whenever(readModel.slice(eq(dataSource), any<ListDatabases.Slice>()))
+            .thenReturn(
+                ListDatabases(
+                    listOf(ListDatabases.Database("myDatabase"))
+                )
+            )
+
+        whenever(readModel.slice(eq(dataSource), any<ListCollections.Slice>()))
+            .thenReturn(
+                ListCollections(
+                    listOf(
+                        ListCollections.Collection("myCollection", "collection")
+                    )
+                )
+            )
 
         whenever(readModel.slice(eq(dataSource), any<ExplainQuery.Slice<Any>>()))
             .thenReturn(ExplainQuery(ExplainPlan.NotRun))

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/correctness/JavaDriverMongoDbFieldDoesNotExistTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/correctness/JavaDriverMongoDbFieldDoesNotExistTest.kt
@@ -3,6 +3,10 @@ package com.mongodb.jbplugin.inspections.correctness
 import com.intellij.openapi.application.Application
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import com.mongodb.jbplugin.accessadapter.slice.GetCollectionSchema
+import com.mongodb.jbplugin.accessadapter.slice.ListCollections
+import com.mongodb.jbplugin.accessadapter.slice.ListCollections.Collection
+import com.mongodb.jbplugin.accessadapter.slice.ListDatabases
+import com.mongodb.jbplugin.accessadapter.slice.ListDatabases.Database
 import com.mongodb.jbplugin.dialects.javadriver.glossary.JavaDriverDialect
 import com.mongodb.jbplugin.fixtures.IntegrationTest
 import com.mongodb.jbplugin.fixtures.ParsingTest
@@ -38,6 +42,14 @@ public FindIterable<Document> exampleFind() {
 
         val (dataSource, readModelProvider) = fixture.setupConnection()
         fixture.specifyDialect(JavaDriverDialect)
+
+        `when`(readModelProvider.slice(eq(dataSource), eq(ListDatabases.Slice))).thenReturn(
+            ListDatabases(listOf(Database("myDatabase")))
+        )
+
+        `when`(readModelProvider.slice(eq(dataSource), any<ListCollections.Slice>())).thenReturn(
+            ListCollections(listOf(Collection("myCollection", "collection")))
+        )
 
         `when`(
             readModelProvider.slice(eq(dataSource), any<GetCollectionSchema.Slice>())
@@ -165,6 +177,14 @@ private Bson getNorQueryWithFieldNameFromMethodCall() {
         val (dataSource, readModelProvider) = fixture.setupConnection()
         fixture.specifyDialect(JavaDriverDialect)
 
+        `when`(readModelProvider.slice(eq(dataSource), eq(ListDatabases.Slice))).thenReturn(
+            ListDatabases(listOf(Database("myDatabase")))
+        )
+
+        `when`(readModelProvider.slice(eq(dataSource), any<ListCollections.Slice>())).thenReturn(
+            ListCollections(listOf(Collection("myCollection", "collection")))
+        )
+
         `when`(
             readModelProvider.slice(eq(dataSource), any<GetCollectionSchema.Slice>())
         ).thenReturn(
@@ -195,6 +215,14 @@ public AggregateIterable<Document> exampleAggregate() {
     ) {
         val (dataSource, readModelProvider) = fixture.setupConnection()
         fixture.specifyDialect(JavaDriverDialect)
+
+        `when`(readModelProvider.slice(eq(dataSource), eq(ListDatabases.Slice))).thenReturn(
+            ListDatabases(listOf(Database("myDatabase")))
+        )
+
+        `when`(readModelProvider.slice(eq(dataSource), any<ListCollections.Slice>())).thenReturn(
+            ListCollections(listOf(Collection("myCollection", "collection")))
+        )
 
         `when`(
             readModelProvider.slice(eq(dataSource), any<GetCollectionSchema.Slice>())
@@ -261,6 +289,14 @@ public AggregateIterable<Document> exampleUnwind3() {
     ) {
         val (dataSource, readModelProvider) = fixture.setupConnection()
         fixture.specifyDialect(JavaDriverDialect)
+
+        `when`(readModelProvider.slice(eq(dataSource), eq(ListDatabases.Slice))).thenReturn(
+            ListDatabases(listOf(Database("myDatabase")))
+        )
+
+        `when`(readModelProvider.slice(eq(dataSource), any<ListCollections.Slice>())).thenReturn(
+            ListCollections(listOf(Collection("myCollection", "collection")))
+        )
 
         `when`(
             readModelProvider.slice(eq(dataSource), any<GetCollectionSchema.Slice>())
@@ -329,6 +365,14 @@ public AggregateIterable<Document> exampleAggregateFields() {
         val (dataSource, readModelProvider) = fixture.setupConnection()
         fixture.specifyDialect(JavaDriverDialect)
 
+        `when`(readModelProvider.slice(eq(dataSource), eq(ListDatabases.Slice))).thenReturn(
+            ListDatabases(listOf(Database("myDatabase")))
+        )
+
+        `when`(readModelProvider.slice(eq(dataSource), any<ListCollections.Slice>())).thenReturn(
+            ListCollections(listOf(Collection("myCollection", "collection")))
+        )
+
         `when`(
             readModelProvider.slice(eq(dataSource), any<GetCollectionSchema.Slice>())
         ).thenReturn(
@@ -389,6 +433,14 @@ public AggregateIterable<Document> exampleAggregateOrderBy() {
         val (dataSource, readModelProvider) = fixture.setupConnection()
         fixture.specifyDialect(JavaDriverDialect)
 
+        `when`(readModelProvider.slice(eq(dataSource), eq(ListDatabases.Slice))).thenReturn(
+            ListDatabases(listOf(Database("myDatabase")))
+        )
+
+        `when`(readModelProvider.slice(eq(dataSource), any<ListCollections.Slice>())).thenReturn(
+            ListCollections(listOf(Collection("myCollection", "collection")))
+        )
+
         `when`(
             readModelProvider.slice(eq(dataSource), any<GetCollectionSchema.Slice>())
         ).thenReturn(
@@ -419,6 +471,14 @@ public AggregateIterable<Document> exampleAggregateOrderBy() {
     ) {
         val (dataSource, readModelProvider) = fixture.setupConnection()
         fixture.specifyDialect(JavaDriverDialect)
+
+        `when`(readModelProvider.slice(eq(dataSource), eq(ListDatabases.Slice))).thenReturn(
+            ListDatabases(listOf(Database("myDatabase")))
+        )
+
+        `when`(readModelProvider.slice(eq(dataSource), any<ListCollections.Slice>())).thenReturn(
+            ListCollections(listOf(Collection("myCollection", "collection")))
+        )
 
         `when`(
             readModelProvider.slice(eq(dataSource), any<GetCollectionSchema.Slice>())
@@ -454,6 +514,14 @@ public AggregateIterable<Document> goodGroupAggregate1() {
     ) {
         val (dataSource, readModelProvider) = fixture.setupConnection()
         fixture.specifyDialect(JavaDriverDialect)
+
+        `when`(readModelProvider.slice(eq(dataSource), eq(ListDatabases.Slice))).thenReturn(
+            ListDatabases(listOf(Database("myDatabase")))
+        )
+
+        `when`(readModelProvider.slice(eq(dataSource), any<ListCollections.Slice>())).thenReturn(
+            ListCollections(listOf(Collection("myCollection", "collection")))
+        )
 
         `when`(
             readModelProvider.slice(eq(dataSource), any<GetCollectionSchema.Slice>())
@@ -500,6 +568,14 @@ public AggregateIterable<Document> goodGroupAggregate2() {
     ) {
         val (dataSource, readModelProvider) = fixture.setupConnection()
         fixture.specifyDialect(JavaDriverDialect)
+
+        `when`(readModelProvider.slice(eq(dataSource), eq(ListDatabases.Slice))).thenReturn(
+            ListDatabases(listOf(Database("myDatabase")))
+        )
+
+        `when`(readModelProvider.slice(eq(dataSource), any<ListCollections.Slice>())).thenReturn(
+            ListCollections(listOf(Collection("myCollection", "collection")))
+        )
 
         `when`(
             readModelProvider.slice(eq(dataSource), any<GetCollectionSchema.Slice>())

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/correctness/JavaDriverMongoDbTypeMismatchTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/correctness/JavaDriverMongoDbTypeMismatchTest.kt
@@ -2,6 +2,10 @@ package com.mongodb.jbplugin.inspections.correctness
 
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import com.mongodb.jbplugin.accessadapter.slice.GetCollectionSchema
+import com.mongodb.jbplugin.accessadapter.slice.ListCollections
+import com.mongodb.jbplugin.accessadapter.slice.ListCollections.Collection
+import com.mongodb.jbplugin.accessadapter.slice.ListDatabases
+import com.mongodb.jbplugin.accessadapter.slice.ListDatabases.Database
 import com.mongodb.jbplugin.dialects.javadriver.glossary.JavaDriverDialect
 import com.mongodb.jbplugin.fixtures.IntegrationTest
 import com.mongodb.jbplugin.fixtures.ParsingTest
@@ -35,6 +39,14 @@ public AggregateIterable<Document> exampleFind() {
     ) {
         val (dataSource, readModelProvider) = fixture.setupConnection()
         fixture.specifyDialect(JavaDriverDialect)
+
+        `when`(readModelProvider.slice(eq(dataSource), eq(ListDatabases.Slice))).thenReturn(
+            ListDatabases(listOf(Database("myDatabase")))
+        )
+
+        `when`(readModelProvider.slice(eq(dataSource), any<ListCollections.Slice>())).thenReturn(
+            ListCollections(listOf(Collection("myCollection", "collection")))
+        )
 
         `when`(
             readModelProvider.slice(eq(dataSource), any<GetCollectionSchema.Slice>())

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/correctness/SpringCriteriaMongoDbFieldDoesNotExistTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/correctness/SpringCriteriaMongoDbFieldDoesNotExistTest.kt
@@ -2,6 +2,10 @@ package com.mongodb.jbplugin.inspections.correctness
 
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import com.mongodb.jbplugin.accessadapter.slice.GetCollectionSchema
+import com.mongodb.jbplugin.accessadapter.slice.ListCollections
+import com.mongodb.jbplugin.accessadapter.slice.ListCollections.Collection
+import com.mongodb.jbplugin.accessadapter.slice.ListDatabases
+import com.mongodb.jbplugin.accessadapter.slice.ListDatabases.Database
 import com.mongodb.jbplugin.dialects.springcriteria.SpringCriteriaDialect
 import com.mongodb.jbplugin.fixtures.DefaultSetup
 import com.mongodb.jbplugin.fixtures.IntegrationTest
@@ -369,6 +373,14 @@ class SpringCriteriaMongoDbFieldDoesNotExistTest {
         val (dataSource, readModelProvider) = fixture.setupConnection()
         fixture.specifyDatabase(dataSource, "bad_db")
         fixture.specifyDialect(SpringCriteriaDialect)
+
+        `when`(readModelProvider.slice(eq(dataSource), eq(ListDatabases.Slice))).thenReturn(
+            ListDatabases(listOf(Database("bad_db")))
+        )
+
+        `when`(readModelProvider.slice(eq(dataSource), any<ListCollections.Slice>())).thenReturn(
+            ListCollections(listOf(Collection("book", "collection")))
+        )
 
         `when`(
             readModelProvider.slice(eq(dataSource), any<GetCollectionSchema.Slice>())

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/correctness/SpringCriteriaMongoDbTypeMismatchTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/correctness/SpringCriteriaMongoDbTypeMismatchTest.kt
@@ -3,6 +3,10 @@ package com.mongodb.jbplugin.inspections.correctness
 import com.intellij.openapi.project.Project
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import com.mongodb.jbplugin.accessadapter.slice.GetCollectionSchema
+import com.mongodb.jbplugin.accessadapter.slice.ListCollections
+import com.mongodb.jbplugin.accessadapter.slice.ListCollections.Collection
+import com.mongodb.jbplugin.accessadapter.slice.ListDatabases
+import com.mongodb.jbplugin.accessadapter.slice.ListDatabases.Database
 import com.mongodb.jbplugin.dialects.springcriteria.SpringCriteriaDialect
 import com.mongodb.jbplugin.fixtures.DefaultSetup
 import com.mongodb.jbplugin.fixtures.IntegrationTest
@@ -50,6 +54,14 @@ class SpringCriteriaMongoDbTypeMismatchTest {
         val (dataSource, readModelProvider) = fixture.setupConnection()
         fixture.specifyDatabase(dataSource, "sample_books")
         fixture.specifyDialect(SpringCriteriaDialect)
+
+        `when`(readModelProvider.slice(eq(dataSource), eq(ListDatabases.Slice))).thenReturn(
+            ListDatabases(listOf(Database("sample_books")))
+        )
+
+        `when`(readModelProvider.slice(eq(dataSource), any<ListCollections.Slice>())).thenReturn(
+            ListCollections(listOf(Collection("book", "collection")))
+        )
 
         `when`(
             readModelProvider.slice(eq(dataSource), any<GetCollectionSchema.Slice>())

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/environmentmismatch/JavaDriverMongoDbCollectionDoesNotExistTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/environmentmismatch/JavaDriverMongoDbCollectionDoesNotExistTest.kt
@@ -70,7 +70,7 @@ public void exampleAggregate2() {
         fixture.specifyDialect(JavaDriverDialect)
 
         `when`(readModelProvider.slice(eq(dataSource), eq(ListDatabases.Slice))).thenReturn(
-            ListDatabases(listOf(Database("myDb")))
+            ListDatabases(listOf(Database("myDatabase")))
         )
 
         `when`(readModelProvider.slice(eq(dataSource), any<ListCollections.Slice>())).thenReturn(

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/environmentmismatch/JavaDriverMongoDbNoCollectionSpecifiedTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/environmentmismatch/JavaDriverMongoDbNoCollectionSpecifiedTest.kt
@@ -41,7 +41,7 @@ public void exampleAggregate(String collectionName) {
         fixture.specifyDialect(JavaDriverDialect)
 
         `when`(readModelProvider.slice(eq(dataSource), eq(ListDatabases.Slice))).thenReturn(
-            ListDatabases(listOf(Database("myDb")))
+            ListDatabases(listOf(Database("myDatabase")))
         )
 
         `when`(readModelProvider.slice(eq(dataSource), any<ListCollections.Slice>())).thenReturn(
@@ -77,7 +77,7 @@ public void exampleAggregate() {
         fixture.specifyDialect(JavaDriverDialect)
 
         `when`(readModelProvider.slice(eq(dataSource), eq(ListDatabases.Slice))).thenReturn(
-            ListDatabases(listOf(Database("myDb")))
+            ListDatabases(listOf(Database("myDatabase")))
         )
 
         `when`(readModelProvider.slice(eq(dataSource), any<ListCollections.Slice>())).thenReturn(

--- a/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/correctness/TypeMismatchInspection.kt
+++ b/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/correctness/TypeMismatchInspection.kt
@@ -32,7 +32,13 @@ class TypeMismatchInspection<D> : QueryInspection<
         settings: TypeMismatchInspectionSettings<D>
     ) {
         val querySchema = knownCollection<Source>()
-            .filter { it.namespace.isValid }
+            .filter {
+                it.namespace.isValid &&
+                    it.namespace.isNamespaceAvailableInCluster(
+                        dataSource = settings.dataSource,
+                        readModelProvider = settings.readModelProvider
+                    )
+            }
             .map {
                 settings.readModelProvider.slice(
                     settings.dataSource,

--- a/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/environmentmismatch/CollectionDoesNotExistInspection.kt
+++ b/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/environmentmismatch/CollectionDoesNotExistInspection.kt
@@ -6,11 +6,26 @@ import com.mongodb.jbplugin.linting.Inspection.CollectionDoesNotExist
 import com.mongodb.jbplugin.linting.QueryInsight
 import com.mongodb.jbplugin.linting.QueryInsightsHolder
 import com.mongodb.jbplugin.linting.QueryInspection
+import com.mongodb.jbplugin.mql.Namespace
 import com.mongodb.jbplugin.mql.Node
 import com.mongodb.jbplugin.mql.adt.Either
 import com.mongodb.jbplugin.mql.parser.components.knownCollection
 import com.mongodb.jbplugin.mql.parser.filter
 import com.mongodb.jbplugin.mql.parser.parse
+
+fun <D>Namespace.isCollectionAvailableInCluster(
+    dataSource: D,
+    readModelProvider: MongoDbReadModelProvider<D>
+): Boolean {
+    val availableCollections = runCatching {
+        readModelProvider.slice(
+            dataSource,
+            ListCollections.Slice(database)
+        ).collections.map { it.name }
+    }.getOrDefault(emptyList())
+
+    return availableCollections.contains(collection)
+}
 
 data class CollectionDoesNotExistInspectionSettings<D>(
     val dataSource: D,
@@ -28,16 +43,19 @@ class CollectionDoesNotExistInspection<D> : QueryInspection<
     ) {
         val parsingResult = knownCollection<Source>()
             .filter { knownRef ->
-                val detectedDatabase = knownRef.namespace.database
-                val detectedCollection = knownRef.namespace.collection
-                val availableCollections = runCatching {
-                    settings.readModelProvider.slice(
-                        settings.dataSource,
-                        ListCollections.Slice(detectedDatabase)
-                    ).collections.map { it.name }
-                }.getOrDefault(emptyList())
+                if (!knownRef.namespace.isDatabaseAvailableInCluster(
+                        dataSource = settings.dataSource,
+                        readModelProvider = settings.readModelProvider
+                    )
+                ) {
+                    // We do not want to trigger the inspection when Database does not even exist
+                    return@filter false
+                }
 
-                !availableCollections.contains(detectedCollection)
+                !knownRef.namespace.isCollectionAvailableInCluster(
+                    dataSource = settings.dataSource,
+                    readModelProvider = settings.readModelProvider
+                )
             }
             .parse(query)
 

--- a/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/environmentmismatch/CollectionDoesNotExistInspection.kt
+++ b/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/environmentmismatch/CollectionDoesNotExistInspection.kt
@@ -16,16 +16,12 @@ import com.mongodb.jbplugin.mql.parser.parse
 fun <D>Namespace.isCollectionAvailableInCluster(
     dataSource: D,
     readModelProvider: MongoDbReadModelProvider<D>
-): Boolean {
-    val availableCollections = runCatching {
-        readModelProvider.slice(
-            dataSource,
-            ListCollections.Slice(database)
-        ).collections.map { it.name }
-    }.getOrDefault(emptyList())
-
-    return availableCollections.contains(collection)
-}
+): Boolean = runCatching {
+    readModelProvider.slice(
+        dataSource,
+        ListCollections.Slice(database)
+    ).collections.any { it.name == collection }
+}.getOrDefault(false)
 
 data class CollectionDoesNotExistInspectionSettings<D>(
     val dataSource: D,

--- a/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/environmentmismatch/DatabaseDoesNotExistInspection.kt
+++ b/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/environmentmismatch/DatabaseDoesNotExistInspection.kt
@@ -16,14 +16,11 @@ import com.mongodb.jbplugin.mql.parser.parse
 fun <D>Namespace.isDatabaseAvailableInCluster(
     dataSource: D,
     readModelProvider: MongoDbReadModelProvider<D>,
-): Boolean {
-    val availableDatabases = runCatching {
-        readModelProvider.slice(dataSource, ListDatabases.Slice).databases.map {
-            it.name
-        }
-    }.getOrDefault(emptyList())
-    return availableDatabases.contains(database)
-}
+): Boolean = runCatching {
+    readModelProvider.slice(dataSource, ListDatabases.Slice).databases.any {
+        it.name == database
+    }
+}.getOrDefault(false)
 
 data class DatabaseDoesNotExistInspectionSettings<D>(
     val dataSource: D,

--- a/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/performance/QueryNotUsingIndexInspection.kt
+++ b/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/performance/QueryNotUsingIndexInspection.kt
@@ -7,10 +7,15 @@ import com.mongodb.jbplugin.linting.Inspection.NotUsingIndex
 import com.mongodb.jbplugin.linting.QueryInsight
 import com.mongodb.jbplugin.linting.QueryInsightsHolder
 import com.mongodb.jbplugin.linting.QueryInspection
+import com.mongodb.jbplugin.linting.correctness.isNamespaceAvailableInCluster
 import com.mongodb.jbplugin.mql.Node
 import com.mongodb.jbplugin.mql.QueryContext
+import com.mongodb.jbplugin.mql.adt.Either
 import com.mongodb.jbplugin.mql.components.HasExplain
 import com.mongodb.jbplugin.mql.components.HasExplain.ExplainPlanType
+import com.mongodb.jbplugin.mql.parser.components.knownCollection
+import com.mongodb.jbplugin.mql.parser.filter
+import com.mongodb.jbplugin.mql.parser.parse
 
 data class QueryNotUsingIndexInspectionSettings<D>(
     val dataSource: D,
@@ -27,6 +32,20 @@ class QueryNotUsingIndexInspection<D> : QueryInspection<
         holder: QueryInsightsHolder<S, NotUsingIndex>,
         settings: QueryNotUsingIndexInspectionSettings<D>
     ) {
+        val validationResults = knownCollection<S>()
+            .filter {
+                it.namespace.isValid &&
+                    it.namespace.isNamespaceAvailableInCluster(
+                        dataSource = settings.dataSource,
+                        readModelProvider = settings.readModelProvider,
+                    )
+            }
+            .parse(query)
+
+        if (validationResults is Either.Left) {
+            return
+        }
+
         val explainPlanResult = settings.readModelProvider.slice(
             settings.dataSource,
             ExplainQuery.Slice(

--- a/packages/mongodb-mql-engines/src/test/kotlin/com/mongodb/jbplugin/linting/correctness/FieldDoesNotExistInspectionTest.kt
+++ b/packages/mongodb-mql-engines/src/test/kotlin/com/mongodb/jbplugin/linting/correctness/FieldDoesNotExistInspectionTest.kt
@@ -1,39 +1,35 @@
 package com.mongodb.jbplugin.linting.correctness
 
-import com.mongodb.jbplugin.accessadapter.slice.GetCollectionSchema
 import com.mongodb.jbplugin.linting.Inspection.FieldDoesNotExist
 import com.mongodb.jbplugin.linting.QueryInspectionTest
 import com.mongodb.jbplugin.mql.BsonBoolean
 import com.mongodb.jbplugin.mql.BsonInt32
 import com.mongodb.jbplugin.mql.BsonObject
 import com.mongodb.jbplugin.mql.BsonString
-import com.mongodb.jbplugin.mql.CollectionSchema
 import com.mongodb.jbplugin.mql.Namespace
 import com.mongodb.jbplugin.mql.Node
 import com.mongodb.jbplugin.mql.components.HasCollectionReference
 import com.mongodb.jbplugin.mql.components.HasFieldReference
 import com.mongodb.jbplugin.mql.components.HasFilter
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.`when`
-import org.mockito.kotlin.any
 
 class FieldDoesNotExistInspectionTest : QueryInspectionTest<FieldDoesNotExist> {
     @Test
     fun `warns about a referenced field not in the specified collection`() = runInspectionTest {
         val collectionNamespace = Namespace("database", "collection")
 
-        `when`(readModelProvider.slice(any(), any<GetCollectionSchema.Slice>())).thenReturn(
-            GetCollectionSchema(
-                CollectionSchema(
-                    collectionNamespace,
-                    BsonObject(
-                        mapOf(
-                            "myString" to BsonString,
-                            "myInt" to BsonInt32,
-                        ),
-                    ),
+        whenDatabasesAre(listOf("database"))
+
+        whenCollectionsAre(listOf("collection"))
+
+        whenCollectionSchemaIs(
+            collectionNamespace,
+            BsonObject(
+                mapOf(
+                    "myString" to BsonString,
+                    "myInt" to BsonInt32,
                 ),
-            ),
+            )
         )
 
         val query = query.with(
@@ -73,21 +69,123 @@ class FieldDoesNotExistInspectionTest : QueryInspectionTest<FieldDoesNotExist> {
     }
 
     @Test
+    fun `does not warn when database does not exist`() = runInspectionTest {
+        val collectionNamespace = Namespace("database", "collection")
+
+        whenDatabasesAre(listOf("database1"))
+
+        whenCollectionsAre(listOf("collection"))
+
+        whenCollectionSchemaIs(
+            collectionNamespace,
+            BsonObject(
+                mapOf(
+                    "myString" to BsonString,
+                    "myBoolean" to BsonBoolean,
+                ),
+            )
+        )
+
+        val query = query.with(
+            HasCollectionReference(
+                HasCollectionReference.Known(null, null, collectionNamespace)
+            )
+        ).with(
+            HasFilter(
+                listOf(
+                    Node(
+                        null,
+                        listOf(
+                            HasFieldReference(
+                                HasFieldReference.FromSchema(null, "myString")
+                            )
+                        )
+                    ),
+                    Node(
+                        null,
+                        listOf(
+                            HasFieldReference(
+                                HasFieldReference.FromSchema(null, "myBoolean")
+                            )
+                        )
+                    ),
+                ),
+            )
+        )
+
+        val inspection = FieldDoesNotExistInspection<Unit>()
+        inspection.run(query, holder, FieldDoesNotExistInspectionSettings(Unit, readModelProvider, 50))
+
+        assertNoInsights()
+    }
+
+    @Test
+    fun `does not warn when collection does not exist`() = runInspectionTest {
+        val collectionNamespace = Namespace("database", "collection")
+
+        whenDatabasesAre(listOf("database"))
+
+        whenCollectionsAre(listOf("collection1"))
+
+        whenCollectionSchemaIs(
+            collectionNamespace,
+            BsonObject(
+                mapOf(
+                    "myString" to BsonString,
+                    "myBoolean" to BsonBoolean,
+                ),
+            )
+        )
+
+        val query = query.with(
+            HasCollectionReference(
+                HasCollectionReference.Known(null, null, collectionNamespace)
+            )
+        ).with(
+            HasFilter(
+                listOf(
+                    Node(
+                        null,
+                        listOf(
+                            HasFieldReference(
+                                HasFieldReference.FromSchema(null, "myString")
+                            )
+                        )
+                    ),
+                    Node(
+                        null,
+                        listOf(
+                            HasFieldReference(
+                                HasFieldReference.FromSchema(null, "myBoolean")
+                            )
+                        )
+                    ),
+                ),
+            )
+        )
+
+        val inspection = FieldDoesNotExistInspection<Unit>()
+        inspection.run(query, holder, FieldDoesNotExistInspectionSettings(Unit, readModelProvider, 50))
+
+        assertNoInsights()
+    }
+
+    @Test
     fun `does not warn when fields are in the schema`() = runInspectionTest {
         val collectionNamespace = Namespace("database", "collection")
 
-        `when`(readModelProvider.slice(any(), any<GetCollectionSchema.Slice>())).thenReturn(
-            GetCollectionSchema(
-                CollectionSchema(
-                    collectionNamespace,
-                    BsonObject(
-                        mapOf(
-                            "myString" to BsonString,
-                            "myBoolean" to BsonBoolean,
-                        ),
-                    ),
+        whenDatabasesAre(listOf("database"))
+
+        whenCollectionsAre(listOf("collection"))
+
+        whenCollectionSchemaIs(
+            collectionNamespace,
+            BsonObject(
+                mapOf(
+                    "myString" to BsonString,
+                    "myBoolean" to BsonBoolean,
                 ),
-            ),
+            )
         )
 
         val query = query.with(

--- a/packages/mongodb-mql-engines/src/test/kotlin/com/mongodb/jbplugin/linting/correctness/TypeMismatchInspectionTest.kt
+++ b/packages/mongodb-mql-engines/src/test/kotlin/com/mongodb/jbplugin/linting/correctness/TypeMismatchInspectionTest.kt
@@ -1,13 +1,11 @@
 package com.mongodb.jbplugin.linting.correctness
 
-import com.mongodb.jbplugin.accessadapter.slice.GetCollectionSchema
 import com.mongodb.jbplugin.linting.Inspection.TypeMismatch
 import com.mongodb.jbplugin.linting.QueryInspectionTest
 import com.mongodb.jbplugin.mql.BsonBoolean
 import com.mongodb.jbplugin.mql.BsonInt32
 import com.mongodb.jbplugin.mql.BsonObject
 import com.mongodb.jbplugin.mql.BsonString
-import com.mongodb.jbplugin.mql.CollectionSchema
 import com.mongodb.jbplugin.mql.Namespace
 import com.mongodb.jbplugin.mql.Node
 import com.mongodb.jbplugin.mql.components.HasCollectionReference
@@ -15,25 +13,23 @@ import com.mongodb.jbplugin.mql.components.HasFieldReference
 import com.mongodb.jbplugin.mql.components.HasFilter
 import com.mongodb.jbplugin.mql.components.HasValueReference
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.`when`
-import org.mockito.kotlin.any
 
 class TypeMismatchInspectionTest : QueryInspectionTest<TypeMismatch> {
     @Test
     fun `warn when a field does not match with the schema type`() = runInspectionTest {
         val collectionNamespace = Namespace("database", "collection")
 
-        `when`(readModelProvider.slice(any(), any<GetCollectionSchema.Slice>())).thenReturn(
-            GetCollectionSchema(
-                CollectionSchema(
-                    collectionNamespace,
-                    BsonObject(
-                        mapOf(
-                            "myString" to BsonString,
-                        ),
-                    ),
+        whenDatabasesAre(listOf("database"))
+
+        whenCollectionsAre(listOf("collection"))
+
+        whenCollectionSchemaIs(
+            collectionNamespace,
+            BsonObject(
+                mapOf(
+                    "myString" to BsonString,
                 ),
-            ),
+            )
         )
 
         val query = query.with(
@@ -73,17 +69,17 @@ class TypeMismatchInspectionTest : QueryInspectionTest<TypeMismatch> {
     fun `warn when a field does not match with the schema type on multiple conditions`() = runInspectionTest {
         val collectionNamespace = Namespace("database", "collection")
 
-        `when`(readModelProvider.slice(any(), any<GetCollectionSchema.Slice>())).thenReturn(
-            GetCollectionSchema(
-                CollectionSchema(
-                    collectionNamespace,
-                    BsonObject(
-                        mapOf(
-                            "myString" to BsonString,
-                        ),
-                    ),
+        whenDatabasesAre(listOf("database"))
+
+        whenCollectionsAre(listOf("collection"))
+
+        whenCollectionSchemaIs(
+            collectionNamespace,
+            BsonObject(
+                mapOf(
+                    "myString" to BsonString,
                 ),
-            ),
+            )
         )
 
         val query = query.with(
@@ -141,18 +137,18 @@ class TypeMismatchInspectionTest : QueryInspectionTest<TypeMismatch> {
     fun `warn when a field does not match with the schema type on multiple fields`() = runInspectionTest {
         val collectionNamespace = Namespace("database", "collection")
 
-        `when`(readModelProvider.slice(any(), any<GetCollectionSchema.Slice>())).thenReturn(
-            GetCollectionSchema(
-                CollectionSchema(
-                    collectionNamespace,
-                    BsonObject(
-                        mapOf(
-                            "myString" to BsonString,
-                            "myStrong" to BsonString,
-                        ),
-                    ),
+        whenDatabasesAre(listOf("database"))
+
+        whenCollectionsAre(listOf("collection"))
+
+        whenCollectionSchemaIs(
+            collectionNamespace,
+            BsonObject(
+                mapOf(
+                    "myString" to BsonString,
+                    "myStrong" to BsonString,
                 ),
-            ),
+            )
         )
 
         val query = query.with(
@@ -207,20 +203,110 @@ class TypeMismatchInspectionTest : QueryInspectionTest<TypeMismatch> {
     }
 
     @Test
+    fun `does not warn if the database does not exist`() = runInspectionTest {
+        val collectionNamespace = Namespace("database", "collection")
+
+        whenDatabasesAre(listOf("database1"))
+
+        whenCollectionsAre(listOf("collection"))
+
+        whenCollectionSchemaIs(
+            collectionNamespace,
+            BsonObject(
+                mapOf(
+                    "myString" to BsonString,
+                ),
+            )
+        )
+
+        val query = query.with(
+            HasCollectionReference(
+                HasCollectionReference.Known(null, null, collectionNamespace)
+            )
+        ).with(
+            HasFilter(
+                listOf(
+                    Node(
+                        null,
+                        listOf(
+                            HasFieldReference(
+                                HasFieldReference.FromSchema(null, "myNonExisting")
+                            ),
+                            HasValueReference(
+                                HasValueReference.Constant(null, 42, BsonInt32)
+                            )
+                        )
+                    )
+                ),
+            )
+        )
+
+        val inspection = TypeMismatchInspection<Unit>()
+        inspection.run(query, holder, TypeMismatchInspectionSettings(Unit, readModelProvider, 50) { it.toString() })
+
+        assertNoInsights()
+    }
+
+    @Test
+    fun `does not warn if the collection does not exist`() = runInspectionTest {
+        val collectionNamespace = Namespace("database", "collection")
+
+        whenDatabasesAre(listOf("database"))
+
+        whenCollectionsAre(listOf("collection1"))
+
+        whenCollectionSchemaIs(
+            collectionNamespace,
+            BsonObject(
+                mapOf(
+                    "myString" to BsonString,
+                ),
+            )
+        )
+
+        val query = query.with(
+            HasCollectionReference(
+                HasCollectionReference.Known(null, null, collectionNamespace)
+            )
+        ).with(
+            HasFilter(
+                listOf(
+                    Node(
+                        null,
+                        listOf(
+                            HasFieldReference(
+                                HasFieldReference.FromSchema(null, "myNonExisting")
+                            ),
+                            HasValueReference(
+                                HasValueReference.Constant(null, 42, BsonInt32)
+                            )
+                        )
+                    )
+                ),
+            )
+        )
+
+        val inspection = TypeMismatchInspection<Unit>()
+        inspection.run(query, holder, TypeMismatchInspectionSettings(Unit, readModelProvider, 50) { it.toString() })
+
+        assertNoInsights()
+    }
+
+    @Test
     fun `does not warn if the field does not exist`() = runInspectionTest {
         val collectionNamespace = Namespace("database", "collection")
 
-        `when`(readModelProvider.slice(any(), any<GetCollectionSchema.Slice>())).thenReturn(
-            GetCollectionSchema(
-                CollectionSchema(
-                    collectionNamespace,
-                    BsonObject(
-                        mapOf(
-                            "myString" to BsonString,
-                        ),
-                    ),
+        whenDatabasesAre(listOf("database"))
+
+        whenCollectionsAre(listOf("collection"))
+
+        whenCollectionSchemaIs(
+            collectionNamespace,
+            BsonObject(
+                mapOf(
+                    "myString" to BsonString,
                 ),
-            ),
+            )
         )
 
         val query = query.with(

--- a/packages/mongodb-mql-engines/src/test/kotlin/com/mongodb/jbplugin/linting/environmentmismatch/DatabaseDoesNotExistInspectionTest.kt
+++ b/packages/mongodb-mql-engines/src/test/kotlin/com/mongodb/jbplugin/linting/environmentmismatch/DatabaseDoesNotExistInspectionTest.kt
@@ -1,14 +1,10 @@
 package com.mongodb.jbplugin.linting.environmentmismatch
 
-import com.mongodb.jbplugin.accessadapter.slice.ListDatabases
-import com.mongodb.jbplugin.accessadapter.slice.ListDatabases.Database
 import com.mongodb.jbplugin.linting.Inspection.DatabaseDoesNotExist
 import com.mongodb.jbplugin.linting.QueryInspectionTest
 import com.mongodb.jbplugin.mql.Namespace
 import com.mongodb.jbplugin.mql.components.HasCollectionReference
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.`when`
-import org.mockito.kotlin.any
 
 class DatabaseDoesNotExistInspectionTest : QueryInspectionTest<DatabaseDoesNotExist> {
     @Test
@@ -24,9 +20,7 @@ class DatabaseDoesNotExistInspectionTest : QueryInspectionTest<DatabaseDoesNotEx
             )
         )
 
-        `when`(readModelProvider.slice(any(), any<ListDatabases.Slice>())).thenReturn(
-            ListDatabases(emptyList())
-        )
+        whenDatabasesAre(emptyList())
 
         val inspection = DatabaseDoesNotExistInspection<Unit>()
         inspection.run(
@@ -57,9 +51,7 @@ class DatabaseDoesNotExistInspectionTest : QueryInspectionTest<DatabaseDoesNotEx
             )
         )
 
-        `when`(readModelProvider.slice(any(), any<ListDatabases.Slice>())).thenReturn(
-            ListDatabases(listOf(Database("database")))
-        )
+        whenDatabasesAre(listOf("database"))
 
         val inspection = DatabaseDoesNotExistInspection<Unit>()
         inspection.run(

--- a/packages/mongodb-mql-engines/src/test/kotlin/com/mongodb/jbplugin/linting/environmentmismatch/NoDatabaseInferredInspectionTest.kt
+++ b/packages/mongodb-mql-engines/src/test/kotlin/com/mongodb/jbplugin/linting/environmentmismatch/NoDatabaseInferredInspectionTest.kt
@@ -1,14 +1,10 @@
 package com.mongodb.jbplugin.linting.environmentmismatch
 
-import com.mongodb.jbplugin.accessadapter.slice.ListCollections
-import com.mongodb.jbplugin.accessadapter.slice.ListCollections.Collection
 import com.mongodb.jbplugin.linting.Inspection.NoDatabaseInferred
 import com.mongodb.jbplugin.linting.QueryInspectionTest
 import com.mongodb.jbplugin.mql.Namespace
 import com.mongodb.jbplugin.mql.components.HasCollectionReference
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.`when`
-import org.mockito.kotlin.any
 
 class NoDatabaseInferredInspectionTest : QueryInspectionTest<NoDatabaseInferred> {
     @Test
@@ -43,11 +39,8 @@ class NoDatabaseInferredInspectionTest : QueryInspectionTest<NoDatabaseInferred>
             )
         )
 
-        `when`(readModelProvider.slice(any(), any<ListCollections.Slice>())).thenReturn(
-            ListCollections(
-                listOf(Collection("collection", "collection"))
-            )
-        )
+        whenDatabasesAre(listOf("database"))
+        whenCollectionsAre(listOf("collection"))
 
         val inspection = NoDatabaseInferredInspection()
         inspection.run(query, holder, Unit)

--- a/packages/mongodb-mql-engines/src/test/kotlin/com/mongodb/jbplugin/linting/performance/QueryNotUsingIndexInspectionTest.kt
+++ b/packages/mongodb-mql-engines/src/test/kotlin/com/mongodb/jbplugin/linting/performance/QueryNotUsingIndexInspectionTest.kt
@@ -1,19 +1,26 @@
 package com.mongodb.jbplugin.linting.performance
 
 import com.mongodb.jbplugin.accessadapter.slice.ExplainPlan
-import com.mongodb.jbplugin.accessadapter.slice.ExplainQuery
 import com.mongodb.jbplugin.linting.Inspection.NotUsingIndex
-import com.mongodb.jbplugin.linting.InspectionTestContext
 import com.mongodb.jbplugin.linting.QueryInspectionTest
+import com.mongodb.jbplugin.mql.Namespace
+import com.mongodb.jbplugin.mql.components.HasCollectionReference
 import com.mongodb.jbplugin.mql.components.HasExplain.ExplainPlanType.SAFE
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.`when`
-import org.mockito.kotlin.any
 
 class QueryNotUsingIndexInspectionTest : QueryInspectionTest<NotUsingIndex> {
     @Test
     fun `warns query plans using a collscan`() = runInspectionTest {
+        val namespace = Namespace("database", "collection")
+        whenDatabasesAre(listOf("database"))
+        whenCollectionsAre(listOf("collection"))
         whenExplainPlanIs(ExplainPlan.CollectionScan)
+
+        val query = query.with(
+            HasCollectionReference(
+                HasCollectionReference.Known(null, null, namespace)
+            )
+        )
 
         val inspection = QueryNotUsingIndexInspection<Unit>()
         inspection.run(query, holder, QueryNotUsingIndexInspectionSettings(Unit, readModelProvider, SAFE))
@@ -22,8 +29,55 @@ class QueryNotUsingIndexInspectionTest : QueryInspectionTest<NotUsingIndex> {
     }
 
     @Test
+    fun `does not warn when database itself does not exist`() = runInspectionTest {
+        val namespace = Namespace("database1", "collection")
+        whenDatabasesAre(listOf("database"))
+        whenCollectionsAre(listOf("collection"))
+        whenExplainPlanIs(ExplainPlan.CollectionScan)
+
+        val query = query.with(
+            HasCollectionReference(
+                HasCollectionReference.Known(null, null, namespace)
+            )
+        )
+
+        val inspection = QueryNotUsingIndexInspection<Unit>()
+        inspection.run(query, holder, QueryNotUsingIndexInspectionSettings(Unit, readModelProvider, SAFE))
+
+        assertNoInsights()
+    }
+
+    @Test
+    fun `does not warn when collection itself does not exist`() = runInspectionTest {
+        val namespace = Namespace("database", "collection1")
+        whenDatabasesAre(listOf("database"))
+        whenCollectionsAre(listOf("collection"))
+        whenExplainPlanIs(ExplainPlan.CollectionScan)
+
+        val query = query.with(
+            HasCollectionReference(
+                HasCollectionReference.Known(null, null, namespace)
+            )
+        )
+
+        val inspection = QueryNotUsingIndexInspection<Unit>()
+        inspection.run(query, holder, QueryNotUsingIndexInspectionSettings(Unit, readModelProvider, SAFE))
+
+        assertNoInsights()
+    }
+
+    @Test
     fun `does not warn on query plans not using an index effectively`() = runInspectionTest {
+        val namespace = Namespace("database", "collection")
+        whenDatabasesAre(listOf("database"))
+        whenCollectionsAre(listOf("collection"))
         whenExplainPlanIs(ExplainPlan.IneffectiveIndexUsage(""))
+
+        val query = query.with(
+            HasCollectionReference(
+                HasCollectionReference.Known(null, null, namespace)
+            )
+        )
 
         val inspection = QueryNotUsingIndexInspection<Unit>()
         inspection.run(query, holder, QueryNotUsingIndexInspectionSettings(Unit, readModelProvider, SAFE))
@@ -33,7 +87,16 @@ class QueryNotUsingIndexInspectionTest : QueryInspectionTest<NotUsingIndex> {
 
     @Test
     fun `does not warn on query plans not using an index scan`() = runInspectionTest {
+        val namespace = Namespace("database", "collection")
+        whenDatabasesAre(listOf("database"))
+        whenCollectionsAre(listOf("collection"))
         whenExplainPlanIs(ExplainPlan.IndexScan(""))
+
+        val query = query.with(
+            HasCollectionReference(
+                HasCollectionReference.Known(null, null, namespace)
+            )
+        )
 
         val inspection = QueryNotUsingIndexInspection<Unit>()
         inspection.run(query, holder, QueryNotUsingIndexInspectionSettings(Unit, readModelProvider, SAFE))
@@ -43,16 +106,20 @@ class QueryNotUsingIndexInspectionTest : QueryInspectionTest<NotUsingIndex> {
 
     @Test
     fun `does not warn on query plans no run`() = runInspectionTest {
+        val namespace = Namespace("database", "collection")
+        whenDatabasesAre(listOf("database"))
+        whenCollectionsAre(listOf("collection"))
         whenExplainPlanIs(ExplainPlan.NotRun)
+
+        val query = query.with(
+            HasCollectionReference(
+                HasCollectionReference.Known(null, null, namespace)
+            )
+        )
 
         val inspection = QueryNotUsingIndexInspection<Unit>()
         inspection.run(query, holder, QueryNotUsingIndexInspectionSettings(Unit, readModelProvider, SAFE))
 
         assertNoInsights()
-    }
-
-    private fun InspectionTestContext<NotUsingIndex>.whenExplainPlanIs(explainPlan: ExplainPlan) {
-        `when`(readModelProvider.slice(any(), any<ExplainQuery.Slice<Unit>>()))
-            .thenReturn(ExplainQuery(explainPlan))
     }
 }


### PR DESCRIPTION
- Database inspection will suppress Collection, Field, Field Type and Query inspections
- Collection inspection will suppress Field, Field Type and Query Inspections
- Field inspection will suppress Field Type inspections

Additionally we will display the Index inlay only when Namespace is available in the cluster.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER-IF-ANY>

  eg. fix(type-hint): infer type of a constant for type checking INTELLIJ-1111
-->

## Description

<!--- Describe your changes in detail so reviewers have enough content on what this PR aims to achieve -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist

- [ ] New tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
- [ ] Changelog is updated accordingly.
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement).

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->