### PR TITLE
fix: autocomplete collections names even without an identified query INTELLIJ-124

### DIFF
--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/JavaDriverCompletionContributorTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/JavaDriverCompletionContributorTest.kt
@@ -56,6 +56,39 @@ class JavaDriverCompletionContributorTest {
     @ParsingTest(
         value = """
     public FindIterable<Document> exampleFind() {
+        return client.getDatabase("myDatabase").getCollection("<caret>");
+    }
+        """,
+    )
+    fun `should autocomplete collections from the current connection and inferred database even without a query`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        fixture.specifyDialect(JavaDriverDialect)
+
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(ListCollections.Slice("myDatabase")))
+        ).thenReturn(
+            ListCollections(
+                listOf(
+                    ListCollections.Collection("myCollection", "collection"),
+                ),
+            ),
+        )
+
+        val elements = fixture.completeBasic()
+
+        assertNotNull(
+            elements.firstOrNull {
+                it.lookupString == "myCollection"
+            },
+        )
+    }
+
+    @ParsingTest(
+        value = """
+    public FindIterable<Document> exampleFind() {
         return client.getDatabase("myDatabase").getCollection("<caret>").find();
     }
         """,

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/JavaDriverMongoDbAutocompletionPopupHandlerTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/autocomplete/JavaDriverMongoDbAutocompletionPopupHandlerTest.kt
@@ -62,6 +62,40 @@ class JavaDriverMongoDbAutocompletionPopupHandlerTest {
     @ParsingTest(
         value = """
     public FindIterable<Document> exampleFind() {
+        return client.getDatabase("myDatabase").getCollection(<caret>);
+    }
+        """,
+    )
+    fun `should autocomplete collections from the current connection and inferred database even without a query`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        fixture.specifyDialect(JavaDriverDialect)
+
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+
+        `when`(
+            readModelProvider.slice(eq(dataSource), eq(ListCollections.Slice("myDatabase")))
+        ).thenReturn(
+            ListCollections(
+                listOf(
+                    ListCollections.Collection("myCollection", "collection"),
+                ),
+            ),
+        )
+
+        fixture.type('"')
+        val elements = fixture.completeBasic()
+
+        assertNotNull(
+            elements.firstOrNull {
+                it.lookupString == "myCollection"
+            },
+        )
+    }
+
+    @ParsingTest(
+        value = """
+    public FindIterable<Document> exampleFind() {
         return client.getDatabase("myDatabase").getCollection(<caret>).find();
     }
         """,

--- a/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParser.kt
+++ b/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParser.kt
@@ -52,6 +52,10 @@ object JavaDriverDialectParser : DialectParser<PsiElement> {
         isCandidateForQuery(it)
     }!!
 
+    override fun parseCollectionReference(source: PsiElement): HasCollectionReference<PsiElement> {
+        return NamespaceExtractor.extractNamespace(source)
+    }
+
     override fun parse(source: PsiElement): Node<PsiElement> {
         val sourceDialect = HasSourceDialect(HasSourceDialect.DialectName.JAVA_DRIVER)
         val collectionReference = NamespaceExtractor.extractNamespace(source)

--- a/packages/mongodb-dialects/spring-@query/src/main/kotlin/com/mongodb/jbplugin/dialects/springquery/SpringAtQueryDialectParser.kt
+++ b/packages/mongodb-dialects/spring-@query/src/main/kotlin/com/mongodb/jbplugin/dialects/springquery/SpringAtQueryDialectParser.kt
@@ -10,6 +10,7 @@ import com.intellij.psi.PsiNameValuePair
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.util.PsiTypesUtil
 import com.intellij.psi.util.elementType
+import com.intellij.psi.util.findParentOfType
 import com.mongodb.jbplugin.dialects.DialectParser
 import com.mongodb.jbplugin.dialects.javadriver.glossary.findAllChildrenOfType
 import com.mongodb.jbplugin.dialects.javadriver.glossary.findTopParentBy
@@ -42,6 +43,11 @@ object SpringAtQueryDialectParser : DialectParser<PsiElement> {
 
     override fun attachment(source: PsiElement): PsiElement {
         return findParentMethodWithQueryAnnotation(source)!!
+    }
+
+    override fun parseCollectionReference(source: PsiElement): HasCollectionReference<PsiElement> {
+        val method = source.findParentOfType<PsiMethod>() ?: return unknownCollectionReference
+        return resolveMethodCollection(method)
     }
 
     override fun parse(source: PsiElement): Node<PsiElement> {

--- a/packages/mongodb-dialects/spring-criteria/src/main/kotlin/com/mongodb/jbplugin/dialects/springcriteria/SpringCriteriaDialectParser.kt
+++ b/packages/mongodb-dialects/spring-criteria/src/main/kotlin/com/mongodb/jbplugin/dialects/springcriteria/SpringCriteriaDialectParser.kt
@@ -48,6 +48,17 @@ object SpringCriteriaDialectParser : DialectParser<PsiElement> {
         isCandidateForQuery(it)
     }!!
 
+    override fun parseCollectionReference(source: PsiElement): HasCollectionReference<PsiElement> {
+        val methodCallExpression = source.parentOfType<PsiMethodCallExpression>(withSelf = true)
+        val maybeMongoOpCall = methodCallExpression?.findSpringMongoDbExpression()
+        val actualMethod = maybeMongoOpCall?.firstChild?.firstChild as? PsiMethodCallExpression
+        return extractCollectionFromQueryChain(maybeMongoOpCall).or(
+            extractCollectionFromClassTypeParameter(
+                actualMethod?.argumentList?.expressions?.getOrNull(1)
+            )
+        )
+    }
+
     override fun parse(source: PsiElement): Node<PsiElement> {
         if (source !is PsiMethodCallExpression) {
             return Node(source, emptyList())

--- a/packages/mongodb-dialects/src/main/kotlin/com/mongodb/jbplugin/dialects/Dialect.kt
+++ b/packages/mongodb-dialects/src/main/kotlin/com/mongodb/jbplugin/dialects/Dialect.kt
@@ -10,6 +10,7 @@ import com.mongodb.jbplugin.indexing.IndexAnalyzer
 import com.mongodb.jbplugin.mql.BsonType
 import com.mongodb.jbplugin.mql.Node
 import com.mongodb.jbplugin.mql.QueryContext
+import com.mongodb.jbplugin.mql.components.HasCollectionReference
 
 /**
  * Represents the dialect itself, S is the input type of the dialect. It's an opaque type,
@@ -55,6 +56,8 @@ interface DialectParser<S> {
     fun isCandidateForQuery(source: S): Boolean
 
     fun attachment(source: S): S
+
+    fun parseCollectionReference(source: S): HasCollectionReference<S>
 
     fun parse(source: S): Node<S>
 


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER-IF-ANY>

  eg. fix(type-hint): infer type of a constant for type checking INTELLIJ-1111
-->

## Description

<!--- Describe your changes in detail so reviewers have enough content on what this PR aims to achieve -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist

- [x] New tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
- [ ] Changelog is updated accordingly.
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement).

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->