### PR TITLE
fix: correctly parses Namespace when multiple queries are in the same method INTELLIJ-165

### DIFF
--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/environmentmismatch/JavaDriverMongoDbDatabaseDoesNotExistTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/environmentmismatch/JavaDriverMongoDbDatabaseDoesNotExistTest.kt
@@ -77,6 +77,33 @@ public void exampleAggregate2() {
     @ParsingTest(
         """
 public FindIterable<Document> exampleFind() {
+    var x = client.getDatabase(
+        <warning descr="Cannot resolve \"bingo\" database reference in the connected data source.">"bingo"</warning>
+    ).getCollection("myCollection").find(eq("nonExistingField", "123"));
+    
+    return client.getDatabase(
+        <warning descr="Cannot resolve \"bango\" database reference in the connected data source.">"bango"</warning>
+    ).getCollection("myCollection").find(eq("nonExistingField", "123"));
+}
+""",
+    )
+    fun `shows database not existing insight correctly when there are multiple queries in the same method`(
+        fixture: CodeInsightTestFixture,
+    ) {
+        val (dataSource, readModelProvider) = fixture.setupConnection()
+        fixture.specifyDialect(JavaDriverDialect)
+
+        `when`(readModelProvider.slice(eq(dataSource), eq(ListDatabases.Slice))).thenReturn(
+            ListDatabases(listOf(Database("myDatabase")))
+        )
+
+        fixture.enableInspections(MongoDbDatabaseDoesNotExist::class.java)
+        fixture.testHighlighting()
+    }
+
+    @ParsingTest(
+        """
+public FindIterable<Document> exampleFind() {
     return client.getDatabase("myDatabase")
             .getCollection("myCollection")
             .find(eq("nonExistingField", "123"));

--- a/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParser.kt
+++ b/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParser.kt
@@ -21,6 +21,8 @@ import com.mongodb.jbplugin.mql.components.HasFieldReference.FromSchema
 import com.mongodb.jbplugin.mql.flattenAnyOfReferences
 import com.mongodb.jbplugin.mql.toBsonType
 
+internal const val MONGO_CLIENT_FQN = "com.mongodb.client.MongoClient"
+internal const val DATABASE_FQN = "com.mongodb.client.MongoDatabase"
 private const val COLLECTION_FQN = "com.mongodb.client.MongoCollection"
 private const val SESSION_FQN = "com.mongodb.client.ClientSession"
 private const val FILTERS_FQN = "com.mongodb.client.model.Filters"


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER-IF-ANY>

  eg. fix(type-hint): infer type of a constant for type checking INTELLIJ-1111
-->

## Description

This PR fixes the issue of only first query getting parsed in a method when there are more than one query in the same method.

The problem was that our NamespaceExtractor looks at the entire file to extract the namespace from (surrounding context) and eventually stumbles upon the method where our query is defined. Now if there are multiple queries in that method then the resolved namespace ends up being that of the first query because of [these lines here](https://github.com/mongodb/intellij/blob/main/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/NamespaceExtractor.kt#L34-L41).

This messes up the rest of the parsing as well. This PR attempts to resolve the namespace first from within the query itself and from the resolvable elements within the query. If we succeed in doing so then good otherwise we fallback to our current method.

Most of the cases (Collection / Database defined as variable, retrieved from a method call) will be covered by changes in this PR and for the cases that the change does not cover we will use the fallback which is the current way of resolving the namespace, from surrounding context.

<!--- Describe your changes in detail so reviewers have enough content on what this PR aims to achieve -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist

- [x] New tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
- [ ] Changelog is updated accordingly.
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement).

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->