### PR TITLE
fix: fixes namespace detection logic unable to resolve database

### DIFF
--- a/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParser.kt
+++ b/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParser.kt
@@ -22,6 +22,7 @@ import com.mongodb.jbplugin.mql.components.HasFieldReference.FromSchema
 import com.mongodb.jbplugin.mql.flattenAnyOfReferences
 import com.mongodb.jbplugin.mql.toBsonType
 
+internal const val MONGO_REACTIVE_CLUSTER_FQN = "com.mongodb.reactivestreams.client.MongoCluster"
 internal const val MONGO_CLUSTER_FQN = "com.mongodb.client.MongoCluster"
 internal const val MONGO_CLIENT_FQN = "com.mongodb.client.MongoClient"
 internal const val DATABASE_FQN = "com.mongodb.client.MongoDatabase"

--- a/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParser.kt
+++ b/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParser.kt
@@ -22,6 +22,7 @@ import com.mongodb.jbplugin.mql.components.HasFieldReference.FromSchema
 import com.mongodb.jbplugin.mql.flattenAnyOfReferences
 import com.mongodb.jbplugin.mql.toBsonType
 
+internal const val MONGO_CLUSTER_FQN = "com.mongodb.client.MongoCluster"
 internal const val MONGO_CLIENT_FQN = "com.mongodb.client.MongoClient"
 internal const val DATABASE_FQN = "com.mongodb.client.MongoDatabase"
 private const val COLLECTION_FQN = "com.mongodb.client.MongoCollection"

--- a/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/NamespaceExtractor.kt
+++ b/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/NamespaceExtractor.kt
@@ -91,7 +91,7 @@ object NamespaceExtractor {
 
         val resolvedGetDatabaseCall = databaseRef.resolveToMethodCallExpression { _, method ->
             method.name == "getDatabase" &&
-                listOf(MONGO_CLUSTER_FQN, MONGO_CLIENT_FQN).contains(
+                listOf(MONGO_REACTIVE_CLUSTER_FQN, MONGO_CLUSTER_FQN, MONGO_CLIENT_FQN).contains(
                     method.containingClass?.qualifiedName
                 )
         } ?: return null

--- a/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/NamespaceExtractor.kt
+++ b/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/NamespaceExtractor.kt
@@ -91,7 +91,9 @@ object NamespaceExtractor {
 
         val resolvedGetDatabaseCall = databaseRef.resolveToMethodCallExpression { _, method ->
             method.name == "getDatabase" &&
-                method.containingClass?.qualifiedName == MONGO_CLIENT_FQN
+                listOf(MONGO_CLUSTER_FQN, MONGO_CLIENT_FQN).contains(
+                    method.containingClass?.qualifiedName
+                )
         } ?: return null
 
         return resolvedGetDatabaseCall.argumentList.expressions.firstOrNull()?.let {


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER-IF-ANY>

  eg. fix(type-hint): infer type of a constant for type checking INTELLIJ-1111
-->

## Description
The API - `getDatabase` was moved to `MongoCluster` class from `MongoClient` class in a release in between `5.1.3` and 5.3.1 - latest. For that reason, we need to be checking getDatabase not just on `MongoClient` but also on `MongoCluster`.

<!--- Describe your changes in detail so reviewers have enough content on what this PR aims to achieve -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist

- [ ] New tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
- [ ] Changelog is updated accordingly.
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement).

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->