### PR TITLE
chore: additional tests to verify inspections for .iterator and .cursor calls INTELLIJ-317

### DIFF
--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/correctness/JavaDriverMongoDbFieldDoesNotExistTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/correctness/JavaDriverMongoDbFieldDoesNotExistTest.kt
@@ -27,6 +27,38 @@ public FindIterable<Document> exampleFind() {
             .getCollection("myCollection")
             .find(eq(<warning descr="Field \"nonExistingField\" does not seem to exist in collection.">"nonExistingField"</warning>, "123"));
 }
+// Additional tests to verify INTELLIJ-317
+public MongoCursor<Document> exampleFind1() {
+    return client.getDatabase("myDatabase")
+            .getCollection("myCollection")
+            .find(eq(<warning descr="Field \"nonExistingField\" does not seem to exist in collection.">"nonExistingField"</warning>, "123")).iterator();
+}
+public MongoCursor<Document> exampleFind3() {
+    return client.getDatabase("myDatabase")
+            .getCollection("myCollection")
+            .find(eq(<warning descr="Field \"nonExistingField\" does not seem to exist in collection.">"nonExistingField"</warning>, "123")).cursor();
+}
+public AggregateIterable<Document> exampleAggregate() {
+    return client.getDatabase("myDatabase")
+            .getCollection("myCollection")
+            .aggregate(List.of(
+                Aggregates.match(eq(<warning descr="Field \"nonExistingField\" does not seem to exist in collection.">"nonExistingField"</warning>, "123"))
+            ));
+}
+public MongoCursor<Document> exampleAggregate1() {
+    return client.getDatabase("myDatabase")
+            .getCollection("myCollection")
+            .aggregate(List.of(
+                Aggregates.match(eq(<warning descr="Field \"nonExistingField\" does not seem to exist in collection.">"nonExistingField"</warning>, "123"))
+            )).iterator();
+}
+public MongoCursor<Document> exampleAggregate2() {
+    return client.getDatabase("myDatabase")
+            .getCollection("myCollection")
+            .aggregate(List.of(
+                Aggregates.match(eq(<warning descr="Field \"nonExistingField\" does not seem to exist in collection.">"nonExistingField"</warning>, "123"))
+            )).cursor();
+}
 """,
     )
     fun `shows an inspection when the field does not exist in the current namespace`(

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/correctness/JavaDriverMongoDbFieldDoesNotExistTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/correctness/JavaDriverMongoDbFieldDoesNotExistTest.kt
@@ -22,37 +22,37 @@ import org.mockito.kotlin.verify
 class JavaDriverMongoDbFieldDoesNotExistTest {
     @ParsingTest(
         """
-public FindIterable<Document> exampleFind() {
+public FindIterable<Document> findIterableShowsWarning() {
     return client.getDatabase("myDatabase")
             .getCollection("myCollection")
             .find(eq(<warning descr="Field \"nonExistingField\" does not seem to exist in collection.">"nonExistingField"</warning>, "123"));
 }
 // Additional tests to verify INTELLIJ-317
-public MongoCursor<Document> exampleFind1() {
+public MongoCursor<Document> findIteratorShowsWarning() {
     return client.getDatabase("myDatabase")
             .getCollection("myCollection")
             .find(eq(<warning descr="Field \"nonExistingField\" does not seem to exist in collection.">"nonExistingField"</warning>, "123")).iterator();
 }
-public MongoCursor<Document> exampleFind3() {
+public MongoCursor<Document> findCursorShowsWarning() {
     return client.getDatabase("myDatabase")
             .getCollection("myCollection")
             .find(eq(<warning descr="Field \"nonExistingField\" does not seem to exist in collection.">"nonExistingField"</warning>, "123")).cursor();
 }
-public AggregateIterable<Document> exampleAggregate() {
+public AggregateIterable<Document> aggregateIterableShowsWarning() {
     return client.getDatabase("myDatabase")
             .getCollection("myCollection")
             .aggregate(List.of(
                 Aggregates.match(eq(<warning descr="Field \"nonExistingField\" does not seem to exist in collection.">"nonExistingField"</warning>, "123"))
             ));
 }
-public MongoCursor<Document> exampleAggregate1() {
+public MongoCursor<Document> aggregateIteratorShowsWarning() {
     return client.getDatabase("myDatabase")
             .getCollection("myCollection")
             .aggregate(List.of(
                 Aggregates.match(eq(<warning descr="Field \"nonExistingField\" does not seem to exist in collection.">"nonExistingField"</warning>, "123"))
             )).iterator();
 }
-public MongoCursor<Document> exampleAggregate2() {
+public MongoCursor<Document> aggregateCursorShowsWarning() {
     return client.getDatabase("myDatabase")
             .getCollection("myCollection")
             .aggregate(List.of(

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/correctness/JavaDriverMongoDbTypeMismatchTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/correctness/JavaDriverMongoDbTypeMismatchTest.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.test.runTest
 class JavaDriverMongoDbTypeMismatchTest {
     @ParsingTest(
         """
-public AggregateIterable<Document> exampleAggregate() {
+public AggregateIterable<Document> aggregateIterableShowsWarning() {
     return client.getDatabase("myDatabase")
             .getCollection("myCollection")
             .aggregate(List.of(
@@ -27,7 +27,7 @@ public AggregateIterable<Document> exampleAggregate() {
             ));
 }
 // Additional tests to verify INTELLIJ-317
-public MongoCursor<Document> exampleAggregate1() {
+public MongoCursor<Document> aggregateIteratorShowsWarning() {
     return client.getDatabase("myDatabase")
             .getCollection("myCollection")
             .aggregate(List.of(
@@ -36,7 +36,7 @@ public MongoCursor<Document> exampleAggregate1() {
                 )
             )).iterator();
 }
-public MongoCursor<Document> exampleAggregate2() {
+public MongoCursor<Document> aggregateCursorShowsWarning() {
     return client.getDatabase("myDatabase")
             .getCollection("myCollection")
             .aggregate(List.of(
@@ -45,17 +45,17 @@ public MongoCursor<Document> exampleAggregate2() {
                 )
             )).cursor();
 }
-public FindIterable<Document> exampleFind() {
+public FindIterable<Document> findIterableShowsWarning() {
     return client.getDatabase("myDatabase")
             .getCollection("myCollection")
             .find(eq("thisIsDouble", <warning descr="Type \"String\" is not compatible with the type of field \"thisIsDouble\" (double).">"123"</warning>));
 }
-public MongoCursor<Document> exampleFind1() {
+public MongoCursor<Document> findIteratorShowsWarning() {
     return client.getDatabase("myDatabase")
             .getCollection("myCollection")
             .find(eq("thisIsDouble", <warning descr="Type \"String\" is not compatible with the type of field \"thisIsDouble\" (double).">"123"</warning>)).iterator();
 }
-public MongoCursor<Document> exampleFind2() {
+public MongoCursor<Document> findCursorShowsWarning() {
     return client.getDatabase("myDatabase")
             .getCollection("myCollection")
             .find(eq("thisIsDouble", <warning descr="Type \"String\" is not compatible with the type of field \"thisIsDouble\" (double).">"123"</warning>)).cursor();

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/correctness/JavaDriverMongoDbTypeMismatchTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inspections/correctness/JavaDriverMongoDbTypeMismatchTest.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.test.runTest
 class JavaDriverMongoDbTypeMismatchTest {
     @ParsingTest(
         """
-public AggregateIterable<Document> exampleFind() {
+public AggregateIterable<Document> exampleAggregate() {
     return client.getDatabase("myDatabase")
             .getCollection("myCollection")
             .aggregate(List.of(
@@ -25,6 +25,40 @@ public AggregateIterable<Document> exampleFind() {
                     eq("thisIsDouble", <warning descr="Type \"String\" is not compatible with the type of field \"thisIsDouble\" (double).">"123"</warning>)
                 )
             ));
+}
+// Additional tests to verify INTELLIJ-317
+public MongoCursor<Document> exampleAggregate1() {
+    return client.getDatabase("myDatabase")
+            .getCollection("myCollection")
+            .aggregate(List.of(
+                Aggregates.match(
+                    eq("thisIsDouble", <warning descr="Type \"String\" is not compatible with the type of field \"thisIsDouble\" (double).">"123"</warning>)
+                )
+            )).iterator();
+}
+public MongoCursor<Document> exampleAggregate2() {
+    return client.getDatabase("myDatabase")
+            .getCollection("myCollection")
+            .aggregate(List.of(
+                Aggregates.match(
+                    eq("thisIsDouble", <warning descr="Type \"String\" is not compatible with the type of field \"thisIsDouble\" (double).">"123"</warning>)
+                )
+            )).cursor();
+}
+public FindIterable<Document> exampleFind() {
+    return client.getDatabase("myDatabase")
+            .getCollection("myCollection")
+            .find(eq("thisIsDouble", <warning descr="Type \"String\" is not compatible with the type of field \"thisIsDouble\" (double).">"123"</warning>));
+}
+public MongoCursor<Document> exampleFind1() {
+    return client.getDatabase("myDatabase")
+            .getCollection("myCollection")
+            .find(eq("thisIsDouble", <warning descr="Type \"String\" is not compatible with the type of field \"thisIsDouble\" (double).">"123"</warning>)).iterator();
+}
+public MongoCursor<Document> exampleFind2() {
+    return client.getDatabase("myDatabase")
+            .getCollection("myCollection")
+            .find(eq("thisIsDouble", <warning descr="Type \"String\" is not compatible with the type of field \"thisIsDouble\" (double).">"123"</warning>)).cursor();
 }
 """,
     )


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER-IF-ANY>

  eg. fix(type-hint): infer type of a constant for type checking INTELLIJ-1111
-->

## Description
Queries terminating with `.iterator` and `.cursor` calls have always been parsed and inspected for insights. The additional test cases are only to confirm the existing behaviour.

The PR adds test cases for:
1. Missing fields insight
2. Field Value type mismatch insight

and each for MongoCursor returned by a `find()` and `aggregate()` call.

<!--- Describe your changes in detail so reviewers have enough content on what this PR aims to achieve -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist

- [ ] New tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
- [ ] Changelog is updated accordingly.
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement).

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->