### PR TITLE
fix: removes slow EDT operation warnings collected by IntelliJ monitor when scope is set to CurrentQuery INTELLIJ-326

### DIFF
--- a/.github/workflows/pr-quality-gate.yaml
+++ b/.github/workflows/pr-quality-gate.yaml
@@ -129,6 +129,7 @@ jobs:
           sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin
 
       - name: Run Unit and Integration Tests
+        timeout-minutes: 10
         run: |
           export DISPLAY=:99.0
           Xvfb -ac :99 -screen 0 1920x1080x24 &
@@ -137,12 +138,12 @@ jobs:
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@a427a90771729d8f85b6ab0cdaa1a5929cab985d # 5.0.0
-        if: success() || failure() # always run even if the previous step fails
+        if: always() # Run this step even if the previous step fails
         with:
           report_paths: "**/build/test-results/test/TEST-*.xml"
 
       - uses: madrapps/jacoco-report@7c362aca34caf958e7b1c03464bd8781db9f8da7 # 1.7.1
-        if: success() || failure() # always run even if the previous step fails
+        if: always() # always run even if the previous step fails
         with:
           paths: "**/testCodeCoverageReport.xml"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/autocomplete/MongoDbCompletionContributor.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/autocomplete/MongoDbCompletionContributor.kt
@@ -330,7 +330,11 @@ private object MongoDbElementPatterns {
         val (collectionReference, command) = runCatching {
             val querySource = dialect.parser.attachment(source)
             val queryService by source.project.service<CachedQueryService>()
-            val parsedQuery = queryService.queryAt(querySource)
+            val parsedQuery = if (querySource != null) {
+                queryService.queryAt(querySource)
+            } else {
+                null
+            }
             val collectionReference = parsedQuery?.component<HasCollectionReference<PsiElement>>()
             val command = parsedQuery?.component<IsCommand>()?.type ?: CommandType.UNKNOWN
             collectionReference to command

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/CachedQueryService.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/CachedQueryService.kt
@@ -60,13 +60,9 @@ class CachedQueryService(
         val dataSource = fileInExpression.dataSource
 
         val dialect = expression.containingFile.dialect ?: return null
-        if (!dialect.parser.isCandidateForQuery(expression)) {
-            return null
-        }
-
-        val attachment = dialect.parser.attachment(expression)
+        val attachment = dialect.parser.attachment(expression) ?: return null
         val psiManager = PsiManager.getInstance(expression.project)
-        if (attachment == null || !psiManager.areElementsEquivalent(expression, attachment)) {
+        if (!psiManager.areElementsEquivalent(expression, attachment)) {
             return null
         }
 

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/CachedQueryService.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/CachedQueryService.kt
@@ -66,7 +66,7 @@ class CachedQueryService(
 
         val attachment = dialect.parser.attachment(expression)
         val psiManager = PsiManager.getInstance(expression.project)
-        if (!psiManager.areElementsEquivalent(expression, attachment)) {
+        if (attachment == null || !psiManager.areElementsEquivalent(expression, attachment)) {
             return null
         }
 

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/inlays/MongoDbQueryIndexStatusInlay.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/inlays/MongoDbQueryIndexStatusInlay.kt
@@ -15,6 +15,7 @@ import com.intellij.codeInsight.hints.InlayHintsSink
 import com.intellij.codeInsight.hints.SettingsKey
 import com.intellij.codeInsight.hints.presentation.MouseButton.Left
 import com.intellij.codeInsight.hints.presentation.PresentationFactory
+import com.intellij.openapi.application.EDT
 import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
@@ -33,7 +34,6 @@ import com.mongodb.jbplugin.i18n.InspectionsAndInlaysMessages
 import com.mongodb.jbplugin.linting.InspectionCategory.PERFORMANCE
 import com.mongodb.jbplugin.linting.correctness.isNamespaceAvailableInCluster
 import com.mongodb.jbplugin.meta.service
-import com.mongodb.jbplugin.meta.withinReadActionBlocking
 import com.mongodb.jbplugin.mql.QueryContext
 import com.mongodb.jbplugin.mql.components.HasCollectionReference
 import com.mongodb.jbplugin.mql.components.HasExplain
@@ -46,8 +46,8 @@ import com.mongodb.jbplugin.ui.viewModel.SidePanelViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jetbrains.jewel.bridge.JewelComposePanel
-import org.jetbrains.letsPlot.commons.debounce
 import java.awt.Cursor
 import javax.swing.JComponent
 
@@ -130,16 +130,11 @@ internal class QueriesInFileCollector(private val coroutineScope: CoroutineScope
                         queryContext
                     )
                 ) {
-                    debounce<Unit>(
-                        delayMs = 1000,
-                        scope = CoroutineScope(Dispatchers.IO)
-                    ) {
-                        withinReadActionBlocking {
-                            InlayHintsPassFactoryInternal.forceHintsUpdateOnNextPass()
-                            DaemonCodeAnalyzer.getInstance(element.project).restart(
-                                element.containingFile
-                            )
-                        }
+                    withContext(Dispatchers.EDT) {
+                        InlayHintsPassFactoryInternal.forceHintsUpdateOnNextPass()
+                        DaemonCodeAnalyzer.getInstance(element.project).restart(
+                            element.containingFile
+                        )
                     }
                 }.explainPlan
             }.getOrDefault(NotRun)

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/ui/viewModel/CodeEditorViewModel.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/ui/viewModel/CodeEditorViewModel.kt
@@ -44,7 +44,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.jetbrains.letsPlot.commons.debounce
 
 data class CaretView(val file: VirtualFile, val offset: Int)
 
@@ -137,12 +136,9 @@ class CodeEditorViewModel(
         }
     }
 
-    fun reanalyzeRelevantEditors() {
-        debounce<Unit>(
-            delayMs = 1000,
-            scope = CoroutineScope(Dispatchers.IO)
-        ) {
-            withinReadActionBlocking {
+    suspend fun reanalyzeRelevantEditors() {
+        withContext(Dispatchers.IO) {
+            withinReadAction {
                 val allPsiFiles = editorState.value.focusedFiles.mapNotNull {
                     it.findPsiFile(project)
                 }

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/ui/viewModel/CodeEditorViewModel.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/ui/viewModel/CodeEditorViewModel.kt
@@ -44,6 +44,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.jetbrains.letsPlot.commons.debounce
 
 data class CaretView(val file: VirtualFile, val offset: Int)
 
@@ -136,9 +137,12 @@ class CodeEditorViewModel(
         }
     }
 
-    suspend fun reanalyzeRelevantEditors() {
-        withContext(Dispatchers.IO) {
-            withinReadAction {
+    fun reanalyzeRelevantEditors() {
+        debounce<Unit>(
+            delayMs = 1000,
+            scope = CoroutineScope(Dispatchers.IO)
+        ) {
+            withinReadActionBlocking {
                 val allPsiFiles = editorState.value.focusedFiles.mapNotNull {
                     it.findPsiFile(project)
                 }

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/codeActions/impl/runQuery/RunQueryModalTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/codeActions/impl/runQuery/RunQueryModalTest.kt
@@ -36,7 +36,7 @@ import java.util.*
 import javax.swing.JFrame
 import kotlin.reflect.KClass
 
-@IntegrationTest
+@IntegrationTest(true)
 class RunQueryModalTest {
     @Test
     fun `has a title and subtitle`(robot: Robot, project: Project, coroutineScope: CoroutineScope) = runTest {

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/fixtures/IntegrationTestExtensions.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/fixtures/IntegrationTestExtensions.kt
@@ -38,6 +38,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.PsiJavaFile
+import com.intellij.psi.PsiManager
 import com.intellij.psi.PsiMethodCallExpression
 import com.intellij.testFramework.IdeaTestUtil
 import com.intellij.testFramework.PsiTestUtil
@@ -558,8 +559,10 @@ public class Repository {
         val candidateQueryExpr = queryMethod.findAllChildrenOfType(
             PsiMethodCallExpression::class.java
         )
+        val psiManager = PsiManager.getInstance(psiFile.project)
         val queryExpr = candidateQueryExpr.first {
-            setup.dialect.parser.isCandidateForQuery(it)
+            val attachment = setup.dialect.parser.attachment(it)
+            psiManager.areElementsEquivalent(attachment, it)
         }
 
         setup.dialect.parser.parse(queryExpr)

--- a/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParser.kt
+++ b/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParser.kt
@@ -76,9 +76,9 @@ object JavaDriverDialectParser : DialectParser<PsiElement> {
         methodCallToCommand((source as? PsiMethodCallExpression)).type !=
             IsCommand.CommandType.UNKNOWN
 
-    override fun attachment(source: PsiElement): PsiElement = source.findTopParentBy {
+    override fun attachment(source: PsiElement): PsiElement? = source.findTopParentBy {
         isCandidateForQuery(it)
-    }!!
+    }
 
     override fun parseCollectionReference(source: PsiElement): HasCollectionReference<PsiElement> {
         return NamespaceExtractor.extractNamespace(source)

--- a/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParser.kt
+++ b/packages/mongodb-dialects/java-driver/src/main/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/JavaDriverDialectParser.kt
@@ -72,12 +72,9 @@ private const val FIND_ITERABLE_FQN = "com.mongodb.client.FindIterable"
 private const val AGGREGATE_ITERABLE_FQN = "com.mongodb.client.AggregateIterable"
 
 object JavaDriverDialectParser : DialectParser<PsiElement> {
-    override fun isCandidateForQuery(source: PsiElement) =
-        methodCallToCommand((source as? PsiMethodCallExpression)).type !=
-            IsCommand.CommandType.UNKNOWN
-
     override fun attachment(source: PsiElement): PsiElement? = source.findTopParentBy {
-        isCandidateForQuery(it)
+        methodCallToCommand((it as? PsiMethodCallExpression)).type !=
+            IsCommand.CommandType.UNKNOWN
     }
 
     override fun parseCollectionReference(source: PsiElement): HasCollectionReference<PsiElement> {

--- a/packages/mongodb-dialects/java-driver/src/test/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/aggregationparser/AggregationParserTest.kt
+++ b/packages/mongodb-dialects/java-driver/src/test/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/aggregationparser/AggregationParserTest.kt
@@ -2,6 +2,7 @@ package com.mongodb.jbplugin.dialects.javadriver.glossary.aggregationparser
 
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiManager
 import com.intellij.psi.PsiMethodCallExpression
 import com.intellij.psi.util.PsiTreeUtil
 import com.mongodb.jbplugin.dialects.javadriver.IntegrationTest
@@ -49,15 +50,26 @@ public final class Aggregation {
       """
     )
     fun `should identify an aggregation as a valid candidate for parsing`(psiFile: PsiFile) {
+        val psiManager = PsiManager.getInstance(psiFile.project)
         val query = psiFile.getQueryAtMethod("Aggregation", "findBookById")
         // The entire aggregation is not a valid candidate
-        assertFalse(JavaDriverDialectParser.isCandidateForQuery(query))
+        assertFalse(
+            psiManager.areElementsEquivalent(
+                query,
+                JavaDriverDialectParser.attachment(query)
+            )
+        )
 
         val actualQuery = PsiTreeUtil
             .findChildrenOfType(query, PsiMethodCallExpression::class.java)
             .first { it.text.endsWith("of())") }
         // Only the collection call is the valid query
-        assertTrue(JavaDriverDialectParser.isCandidateForQuery(actualQuery))
+        assertTrue(
+            psiManager.areElementsEquivalent(
+                query,
+                JavaDriverDialectParser.attachment(actualQuery)
+            )
+        )
     }
 
     @ParsingTest(

--- a/packages/mongodb-dialects/java-driver/src/test/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/aggregationparser/AggregationParserTest.kt
+++ b/packages/mongodb-dialects/java-driver/src/test/kotlin/com/mongodb/jbplugin/dialects/javadriver/glossary/aggregationparser/AggregationParserTest.kt
@@ -66,7 +66,7 @@ public final class Aggregation {
         // Only the collection call is the valid query
         assertTrue(
             psiManager.areElementsEquivalent(
-                query,
+                actualQuery,
                 JavaDriverDialectParser.attachment(actualQuery)
             )
         )

--- a/packages/mongodb-dialects/spring-@query/src/main/kotlin/com/mongodb/jbplugin/dialects/springquery/SpringAtQueryDialectParser.kt
+++ b/packages/mongodb-dialects/spring-@query/src/main/kotlin/com/mongodb/jbplugin/dialects/springquery/SpringAtQueryDialectParser.kt
@@ -37,10 +37,6 @@ object SpringAtQueryDialectParser : DialectParser<PsiElement> {
         HasCollectionReference.Unknown as HasCollectionReference.CollectionReference<PsiElement>
     )
 
-    override fun isCandidateForQuery(source: PsiElement): Boolean {
-        return findParentMethodWithQueryAnnotation(source) != null
-    }
-
     override fun attachment(source: PsiElement): PsiElement? {
         return findParentMethodWithQueryAnnotation(source)
     }

--- a/packages/mongodb-dialects/spring-@query/src/main/kotlin/com/mongodb/jbplugin/dialects/springquery/SpringAtQueryDialectParser.kt
+++ b/packages/mongodb-dialects/spring-@query/src/main/kotlin/com/mongodb/jbplugin/dialects/springquery/SpringAtQueryDialectParser.kt
@@ -41,8 +41,8 @@ object SpringAtQueryDialectParser : DialectParser<PsiElement> {
         return findParentMethodWithQueryAnnotation(source) != null
     }
 
-    override fun attachment(source: PsiElement): PsiElement {
-        return findParentMethodWithQueryAnnotation(source)!!
+    override fun attachment(source: PsiElement): PsiElement? {
+        return findParentMethodWithQueryAnnotation(source)
     }
 
     override fun parseCollectionReference(source: PsiElement): HasCollectionReference<PsiElement> {

--- a/packages/mongodb-dialects/spring-criteria/src/main/kotlin/com/mongodb/jbplugin/dialects/springcriteria/SpringCriteriaDialectParser.kt
+++ b/packages/mongodb-dialects/spring-criteria/src/main/kotlin/com/mongodb/jbplugin/dialects/springcriteria/SpringCriteriaDialectParser.kt
@@ -74,9 +74,9 @@ object SpringCriteriaDialectParser : DialectParser<PsiElement> {
         inferCommandFromMethod((source as? PsiMethodCallExpression)?.fuzzyResolveMethod()).type !=
             IsCommand.CommandType.UNKNOWN
 
-    override fun attachment(source: PsiElement): PsiElement = source.findTopParentBy {
+    override fun attachment(source: PsiElement): PsiElement? = source.findTopParentBy {
         isCandidateForQuery(it)
-    }!!
+    }
 
     override fun parseCollectionReference(source: PsiElement): HasCollectionReference<PsiElement> {
         val methodCallExpression = source.parentOfType<PsiMethodCallExpression>(withSelf = true)

--- a/packages/mongodb-dialects/spring-criteria/src/main/kotlin/com/mongodb/jbplugin/dialects/springcriteria/SpringCriteriaDialectParser.kt
+++ b/packages/mongodb-dialects/spring-criteria/src/main/kotlin/com/mongodb/jbplugin/dialects/springcriteria/SpringCriteriaDialectParser.kt
@@ -70,12 +70,10 @@ object SpringCriteriaDialectParser : DialectParser<PsiElement> {
         GroupStageParser(),
     )
 
-    override fun isCandidateForQuery(source: PsiElement) =
-        inferCommandFromMethod((source as? PsiMethodCallExpression)?.fuzzyResolveMethod()).type !=
-            IsCommand.CommandType.UNKNOWN
-
     override fun attachment(source: PsiElement): PsiElement? = source.findTopParentBy {
-        isCandidateForQuery(it)
+        inferCommandFromMethod(
+            (it as? PsiMethodCallExpression)?.fuzzyResolveMethod()
+        ).type != IsCommand.CommandType.UNKNOWN
     }
 
     override fun parseCollectionReference(source: PsiElement): HasCollectionReference<PsiElement> {

--- a/packages/mongodb-dialects/src/main/kotlin/com/mongodb/jbplugin/dialects/Dialect.kt
+++ b/packages/mongodb-dialects/src/main/kotlin/com/mongodb/jbplugin/dialects/Dialect.kt
@@ -6,9 +6,6 @@
 
 package com.mongodb.jbplugin.dialects
 
-import com.mongodb.jbplugin.dialects.OutputQuery.CanBeRun
-import com.mongodb.jbplugin.dialects.OutputQuery.Incomplete
-import com.mongodb.jbplugin.dialects.OutputQuery.None
 import com.mongodb.jbplugin.indexing.IndexAnalyzer
 import com.mongodb.jbplugin.mql.BsonType
 import com.mongodb.jbplugin.mql.Node
@@ -58,7 +55,7 @@ interface Dialect<S, C> {
 interface DialectParser<S> {
     fun isCandidateForQuery(source: S): Boolean
 
-    fun attachment(source: S): S
+    fun attachment(source: S): S?
 
     fun parseCollectionReference(source: S): HasCollectionReference<S>
 

--- a/packages/mongodb-dialects/src/main/kotlin/com/mongodb/jbplugin/dialects/Dialect.kt
+++ b/packages/mongodb-dialects/src/main/kotlin/com/mongodb/jbplugin/dialects/Dialect.kt
@@ -53,8 +53,6 @@ interface Dialect<S, C> {
  * @param S
  */
 interface DialectParser<S> {
-    fun isCandidateForQuery(source: S): Boolean
-
     fun attachment(source: S): S?
 
     fun parseCollectionReference(source: S): HasCollectionReference<S>


### PR DESCRIPTION
## Description
Earlier we were refreshing the scope analysis on every
keystroke -> caret changes and that was causing the
CurrentQuery scope to filter out the queries on EDT
thread which is expensive because in the filter method
we use CachedQueryService.queryAt which traverses the
Psi tree, and it comes at a cost.

Now we will debounce caret changes and refresh only after
a certain time as passed which will at-least keep us from
querying CachedQueryService to a minimum during active
development.

This is still far from ideal. Ideally we should assume
that operations such as tree traversal is costly and thus
should be done suspended but that is for another commit,
perhaps. This one should remove the immediate threat for
now.

<!--- Describe your changes in detail so reviewers have enough content on what this PR aims to achieve -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist

- [ ] New tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
- [ ] Changelog is updated accordingly.
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement).

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->