### PR TITLE
chore: keep only verifyPlugin in the scheduled and make versionBump cacheable

### DIFF
--- a/.github/workflows/act-draft-release.yaml
+++ b/.github/workflows/act-draft-release.yaml
@@ -101,12 +101,6 @@ jobs:
         run: |
           ./gradlew --quiet --console=plain ":packages:jetbrains-plugin:patchPluginXml"
 
-      - name: Verify Plugin
-        env:
-          BUILD_SEGMENT_API_KEY: ''
-        run: |
-          ./gradlew --quiet --console=plain ":packages:jetbrains-plugin:verifyPlugin"
-
       - name: Sign and Publish Plugin in Beta
         if: ${{ github.event.inputs.dryRun != 'true' }}
         env:

--- a/.github/workflows/pr-quality-gate.yaml
+++ b/.github/workflows/pr-quality-gate.yaml
@@ -179,7 +179,3 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@8379f6a1328ee0e06e2bb424dadb7b159856a326 # v.4.4.0
-
-      - name: Verify Plugin
-        run: |
-          ./gradlew --quiet --console=plain ":packages:jetbrains-plugin:verifyPlugin"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,12 +63,11 @@ tasks {
             }
             return "$newMajor.$newMinor.$newPatch"
         }
-        doLast {
-            val newVersion = rootProject.findProperty("exactVersion") ?: generateVersion()
-            val oldContent = buildFile.readText()
-            val newContent = oldContent.replace(""" = "$version"""", """ = "$newVersion"""")
-            buildFile.writeText(newContent)
-        }
+
+        val newVersion = rootProject.findProperty("exactVersion") ?: generateVersion()
+        val oldContent = buildFile.readText()
+        val newContent = oldContent.replace(""" = "$version"""", """ = "$newVersion"""")
+        buildFile.writeText(newContent)
     }
 
     register<Exec>("gitHooks") {


### PR DESCRIPTION
verifyPlugin is a really expensive task, as it requires to download from 3 to 4 IntelliJ IDEA versions to run (around 1.5GB per IDE version) and this overloads the runners that we use during CI. Because we are running the verifyPlugin task once every day, and it's also run in the marketplace before publishing, we can get rid of it and only keep it in our scheduled nightly task.

Also, this PR makes versionBump's configuration cacheable for Gradle by removing the doLast lifecycle, which makes the task itself faster with the same behaviour (in our case).