### PR TITLE
chore: ignore sort operations in the type mismatch linter INTELLIJ-333

### DIFF
--- a/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/correctness/TypeMismatchInspection.kt
+++ b/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/correctness/TypeMismatchInspection.kt
@@ -12,6 +12,8 @@ import com.mongodb.jbplugin.mql.CollectionSchema
 import com.mongodb.jbplugin.mql.Node
 import com.mongodb.jbplugin.mql.adt.Either
 import com.mongodb.jbplugin.mql.components.HasFieldReference
+import com.mongodb.jbplugin.mql.components.Name
+import com.mongodb.jbplugin.mql.components.Named
 import com.mongodb.jbplugin.mql.parser.components.ParsedValueReference
 import com.mongodb.jbplugin.mql.parser.components.allNodesWithSchemaFieldReferences
 import com.mongodb.jbplugin.mql.parser.components.extractValueReferencesRelevantForIndexing
@@ -61,6 +63,7 @@ class TypeMismatchInspection<D> : QueryInspection<
                 val collectionSchema = querySchema.value
 
                 val allFieldsAndValuesResult = allNodesWithSchemaFieldReferences<Source>()
+                    .map { node -> node.filter { it.component<Named>()?.name != Name.SORT } }
                     .mapMany(
                         schemaFieldReference<Source>()
                             .zip(

--- a/packages/mongodb-mql-engines/src/test/kotlin/com/mongodb/jbplugin/linting/correctness/TypeMismatchInspectionTest.kt
+++ b/packages/mongodb-mql-engines/src/test/kotlin/com/mongodb/jbplugin/linting/correctness/TypeMismatchInspectionTest.kt
@@ -12,6 +12,8 @@ import com.mongodb.jbplugin.mql.components.HasCollectionReference
 import com.mongodb.jbplugin.mql.components.HasFieldReference
 import com.mongodb.jbplugin.mql.components.HasFilter
 import com.mongodb.jbplugin.mql.components.HasValueReference
+import com.mongodb.jbplugin.mql.components.Name
+import com.mongodb.jbplugin.mql.components.Named
 import org.junit.jupiter.api.Test
 
 class TypeMismatchInspectionTest : QueryInspectionTest<TypeMismatch> {
@@ -327,6 +329,51 @@ class TypeMismatchInspectionTest : QueryInspectionTest<TypeMismatch> {
                             )
                         )
                     )
+                ),
+            )
+        )
+
+        val inspection = TypeMismatchInspection<Unit>()
+        inspection.run(query, holder, TypeMismatchInspectionSettings(Unit, readModelProvider, 50) { it.toString() })
+
+        assertNoInsights()
+    }
+
+    @Test
+    fun `does not warn on sorts`() = runInspectionTest {
+        val collectionNamespace = Namespace("database", "collection")
+
+        whenDatabasesAre(listOf("database"))
+        whenCollectionsAre(listOf("collection"))
+
+        whenCollectionSchemaIs(
+            collectionNamespace,
+            BsonObject(
+                mapOf(
+                    "myString" to BsonString,
+                ),
+            )
+        )
+
+        val query = query.with(
+            HasCollectionReference(
+                HasCollectionReference.Known(null, null, collectionNamespace)
+            )
+        ).with(
+            HasFilter(
+                listOf(
+                    Node(
+                        null,
+                        listOf(
+                            Named(Name.SORT),
+                            HasFieldReference(
+                                HasFieldReference.FromSchema(null, "myString")
+                            ),
+                            HasValueReference(
+                                HasValueReference.Constant(null, 42, BsonInt32)
+                            )
+                        )
+                    ),
                 ),
             )
         )


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER-IF-ANY>

  eg. fix(type-hint): infer type of a constant for type checking INTELLIJ-1111
-->

## Description

<!--- Describe your changes in detail so reviewers have enough content on what this PR aims to achieve -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist

- [ ] New tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
- [ ] Changelog is updated accordingly.
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement).

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->