### PR TITLE
chore: avoid using PsiFile.virtualFile directly because throws an exception INTELLIJ-346

### DIFF
--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/autocomplete/MongoDbCompletionContributor.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/autocomplete/MongoDbCompletionContributor.kt
@@ -38,6 +38,7 @@ import com.mongodb.jbplugin.editor.MongoDbVirtualFileDataSourceProvider
 import com.mongodb.jbplugin.editor.dataSource
 import com.mongodb.jbplugin.editor.database
 import com.mongodb.jbplugin.editor.dialect
+import com.mongodb.jbplugin.editor.virtualFileOrNull
 import com.mongodb.jbplugin.i18n.Icons
 import com.mongodb.jbplugin.meta.service
 import com.mongodb.jbplugin.mql.Namespace
@@ -200,12 +201,12 @@ private object MongoDbElementPatterns {
 
             private fun isFileConnected(psiFile: PsiFile?): Boolean {
                 psiFile ?: return false
-                psiFile.originalFile.virtualFile ?: return false
+                val virtualFile = psiFile.originalFile.virtualFileOrNull ?: return false
 
                 val dbDataSource =
                     MongoDbVirtualFileDataSourceProvider().getDataSource(
                         psiFile.project,
-                        psiFile.originalFile.virtualFile,
+                        virtualFile,
                     )
 
                 return !(

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/DatagripConsoleEditor.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/DatagripConsoleEditor.kt
@@ -50,7 +50,7 @@ interface DatagripConsoleEditor {
         private fun allConsoleEditorsForDataSource(project: Project, dataSource: LocalDataSource): List<Editor> =
             EditorFactory.getInstance().allEditors.filter {
                 val psiFile = PsiDocumentManager.getInstance(project).getPsiFile(it.document)
-                val virtualFile = psiFile?.virtualFile ?: return@filter false
+                val virtualFile = psiFile?.virtualFileOrNull ?: return@filter false
                 val dataSourceOfFile = DbVFSUtils.getDataSource(project, virtualFile)
                 dataSource == dataSourceOfFile
             }

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/MongoDbVirtualFileDataSourceProvider.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/MongoDbVirtualFileDataSourceProvider.kt
@@ -37,6 +37,11 @@ val PsiFile.database: String?
             }
     }.getOrNull()
 
+val PsiFile.virtualFileOrNull: VirtualFile?
+    get() = runCatching {
+        virtualFile
+    }.getOrNull()
+
 val VirtualFile.identifiedDialects: List<Dialect<PsiElement, Project>>
     get() = runCatching {
         MongoDbVirtualFileDataSourceProvider().getDialects(this)
@@ -46,7 +51,7 @@ val VirtualFile.dialect: Dialect<PsiElement, Project>?
     get() = identifiedDialects.firstOrNull()
 
 val PsiFile.dialect: Dialect<PsiElement, Project>?
-    get() = virtualFile.dialect
+    get() = virtualFileOrNull?.dialect
 
 /**
  * Returns the data source, if attached to the editor through the MongoDB Plugin.

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/inspections/analysisScope/AnalysisScope.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/inspections/analysisScope/AnalysisScope.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
+import com.mongodb.jbplugin.editor.virtualFileOrNull
 import com.mongodb.jbplugin.linting.QueryInsight
 import com.mongodb.jbplugin.meta.service
 import com.mongodb.jbplugin.meta.withinReadActionBlocking
@@ -42,9 +43,9 @@ sealed interface AnalysisScope {
             try {
                 val codeEditorViewModel by project.service<CodeEditorViewModel>()
                 val relevantFiles = codeEditorViewModel.editorState.value.focusedFiles
-
                 return allInsights.filter {
-                    relevantFiles.contains(it.query.source.containingFile.virtualFile)
+                    val virtualFile = it.query.source.containingFile.virtualFileOrNull ?: return@filter false
+                    relevantFiles.contains(virtualFile)
                 }
             } catch (e: Exception) {
                 log.warn(useLogMessage("Unable to filter relevant insights").build(), e)
@@ -111,7 +112,8 @@ sealed interface AnalysisScope {
                     findOpenFilesCommonPrefix(codeEditorViewModel) ?: return emptyList()
 
                 return allInsights.filter {
-                    it.query.source.containingFile.virtualFile.path.startsWith(sharedParent)
+                    val virtualFile = it.query.source.containingFile.virtualFileOrNull ?: return@filter false
+                    virtualFile.path.startsWith(sharedParent)
                 }
             } catch (e: Exception) {
                 log.warn(useLogMessage("Unable to filter relevant insights").build(), e)

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/ui/viewModel/CodeEditorViewModel.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/ui/viewModel/CodeEditorViewModel.kt
@@ -32,6 +32,7 @@ import com.mongodb.jbplugin.editor.CachedQueryService
 import com.mongodb.jbplugin.editor.MongoDbVirtualFileDataSourceProvider.Keys
 import com.mongodb.jbplugin.editor.dialect
 import com.mongodb.jbplugin.editor.services.MdbPluginDisposable
+import com.mongodb.jbplugin.editor.virtualFileOrNull
 import com.mongodb.jbplugin.meta.containingFileOrNull
 import com.mongodb.jbplugin.meta.service
 import com.mongodb.jbplugin.meta.withinReadAction
@@ -153,7 +154,7 @@ class CodeEditorViewModel(
 
     suspend fun focusQueryInEditor(query: Node<PsiElement>, fileEditorManager: FileEditorManager? = null) {
         withContext(Dispatchers.EDT) {
-            val vFile = query.containingFileOrNull?.virtualFile ?: return@withContext
+            val vFile = query.containingFileOrNull?.virtualFileOrNull ?: return@withContext
 
             val manager = fileEditorManager ?: FileEditorManager.getInstance(query.source.project)
             val editorOfFile = manager.selectedTextEditor?.takeIf { it.virtualFile == vFile }


### PR DESCRIPTION
PsiFile.virtualFile throws an exception when the PsiElement is not related to a file anymore, which is problematic. Now we are using virtualFileOrNull that will return null instead so it can be early checked.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER-IF-ANY>

  eg. fix(type-hint): infer type of a constant for type checking INTELLIJ-1111
-->

## Description

<!--- Describe your changes in detail so reviewers have enough content on what this PR aims to achieve -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist

- [ ] New tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
- [ ] Changelog is updated accordingly.
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement).

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->