### PR TITLE
chore: fallback to software rendering if skiko can not use gpu acceleration

### DIFF
--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/ui/components/SidePanel.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/ui/components/SidePanel.kt
@@ -6,11 +6,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
 import com.mongodb.jbplugin.meta.service
+import com.mongodb.jbplugin.observability.useLogMessage
 import com.mongodb.jbplugin.ui.components.connection.ConnectionBootstrapCard
 import com.mongodb.jbplugin.ui.components.connection.OnlyWhenConnected
 import com.mongodb.jbplugin.ui.components.inspections.InspectionAccordion
@@ -19,17 +21,45 @@ import com.mongodb.jbplugin.ui.components.utilities.hooks.LocalProject
 import com.mongodb.jbplugin.ui.viewModel.SidePanelStatus
 import com.mongodb.jbplugin.ui.viewModel.SidePanelViewModel
 import org.jetbrains.jewel.bridge.addComposeTab
+import org.jetbrains.skiko.SkikoProperties
 
 const val MDB_SIDEPANEL_ID = "MongoDB"
+private val log = logger<SidePanel>()
 
 class SidePanel : ToolWindowFactory, DumbAware {
     override fun createToolWindowContent(
         project: Project,
         toolWindow: ToolWindow
     ) {
+        log.info(
+            useLogMessage("Rendering SidePanel for the first time")
+                .put("skiko.renderApi", SkikoProperties.renderApi.name)
+                .build(),
+        )
+
         val viewModel by project.service<SidePanelViewModel>()
         viewModel.setStatus(SidePanelStatus.Warning)
 
+        try {
+            doRender(toolWindow, project)
+        } catch (ex: Throwable) {
+            val originalSkikoApi = SkikoProperties.renderApi.name
+            System.setProperty("skiko.renderApi", "SOFTWARE")
+            val fallbackSkikoApi = SkikoProperties.renderApi.name
+
+            log.warn(
+                useLogMessage("Could not use GPU accelerated rendering: " + (ex.message ?: "<no error message>"))
+                    .put("original.skiko.renderApi", originalSkikoApi)
+                    .put("fallback.skiko.renderApi", fallbackSkikoApi)
+                    .build(),
+                ex
+            )
+
+            doRender(toolWindow, project)
+        }
+    }
+
+    private fun doRender(toolWindow: ToolWindow, project: Project) {
         toolWindow.addComposeTab(isLockable = true, isCloseable = false) {
             CompositionLocalProvider(
                 LocalProject provides project


### PR DESCRIPTION
It mitigates this bug: https://youtrack.jetbrains.com/issue/JEWEL-848/Skiko-crashes-when-DirectX12-is-not-available-and-does-not-fallback-to-SOFTWARE

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER-IF-ANY>

  eg. fix(type-hint): infer type of a constant for type checking INTELLIJ-1111
-->

## Description

<!--- Describe your changes in detail so reviewers have enough content on what this PR aims to achieve -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist

- [ ] New tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
- [ ] Changelog is updated accordingly.
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement).

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->