### PR TITLE
fix: show no index warnings when a query has no filters INTELLIJ-360

### DIFF
--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/CachedQueryService.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/CachedQueryService.kt
@@ -108,10 +108,9 @@ class CachedQueryService(
             }
 
             attachment.putUserData(queryCacheKey, cachedValue)
-            return decorateWithMetadata(
-                dataSource,
-                attachment.getUserData(queryCacheKey)!!.value
-            )
+            return attachment.getUserData(queryCacheKey)?.value?.let {
+                decorateWithMetadata(dataSource, it)
+            }
         } catch (pce: ProcessCanceledException) {
             throw pce
         } catch (ex: Exception) {

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/inspections/AbstractMongoDbInspectionBridge.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/inspections/AbstractMongoDbInspectionBridge.kt
@@ -38,6 +38,7 @@ import com.mongodb.jbplugin.linting.Inspection.FieldDoesNotExist
 import com.mongodb.jbplugin.linting.Inspection.InvalidProjection
 import com.mongodb.jbplugin.linting.Inspection.NoCollectionSpecified
 import com.mongodb.jbplugin.linting.Inspection.NoDatabaseInferred
+import com.mongodb.jbplugin.linting.Inspection.NotUsingFilters
 import com.mongodb.jbplugin.linting.Inspection.NotUsingIndex
 import com.mongodb.jbplugin.linting.Inspection.NotUsingIndexEffectively
 import com.mongodb.jbplugin.linting.Inspection.TypeMismatch
@@ -63,6 +64,8 @@ abstract class AbstractMongoDbInspectionGlobalTool(
     // still do it here anyway to avoid as much human error as possible when modifying metadata
     // in plugin.xml.
     override fun getShortName(): String = inspection.javaClass.simpleName
+
+    override fun getStaticDescription(): String? = inspection.javaClass.simpleName
 
     override fun worksInBatchModeOnly() = false
 
@@ -172,7 +175,9 @@ abstract class AbstractMongoDbInspectionBridge<Settings, I : Inspection>(
                 *insight.descriptionArguments.toTypedArray()
             )
             val problemHighlightType = when (insight.inspection) {
-                NotUsingIndex, NotUsingIndexEffectively -> HighlightSeverity.INFORMATION
+                NotUsingIndex,
+                NotUsingIndexEffectively,
+                NotUsingFilters -> HighlightSeverity.INFORMATION
                 else -> HighlightSeverity.WARNING
             }
 

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/inspections/performance/MongoDbQueryNotUsingFilters.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/inspections/performance/MongoDbQueryNotUsingFilters.kt
@@ -1,0 +1,46 @@
+package com.mongodb.jbplugin.inspections.performance
+
+import com.intellij.psi.PsiElement
+import com.mongodb.jbplugin.inspections.AbstractMongoDbInspectionBridge
+import com.mongodb.jbplugin.inspections.AbstractMongoDbInspectionGlobalTool
+import com.mongodb.jbplugin.linting.Inspection.NotUsingFilters
+import com.mongodb.jbplugin.linting.QueryInsight
+import com.mongodb.jbplugin.linting.performance.QueryNotUsingFiltersInspection
+import com.mongodb.jbplugin.meta.service
+import com.mongodb.jbplugin.mql.Node
+import com.mongodb.jbplugin.observability.TelemetryEvent
+import com.mongodb.jbplugin.observability.probe.InspectionStatusChangedProbe
+import kotlinx.coroutines.CoroutineScope
+
+class MongoDbQueryNotUsingFiltersGlobalTool : AbstractMongoDbInspectionGlobalTool(
+    NotUsingFilters
+)
+
+class MongoDbQueryNotUsingFilters(coroutineScope: CoroutineScope) : AbstractMongoDbInspectionBridge<
+    Unit,
+    NotUsingFilters
+    >(
+    coroutineScope = coroutineScope,
+    queryInspection = QueryNotUsingFiltersInspection(),
+    inspection = NotUsingFilters
+) {
+    override fun buildSettings(query: Node<PsiElement>) {}
+
+    override fun afterInsight(queryInsight: QueryInsight<PsiElement, NotUsingFilters>) {
+        val probe by service<InspectionStatusChangedProbe>()
+        probe.inspectionChanged(
+            TelemetryEvent.InspectionStatusChangeEvent.InspectionType.QUERY_NOT_COVERED_BY_INDEX,
+            queryInsight.query
+        )
+    }
+
+    override fun emitFinishedInspectionTelemetryEvent(
+        queryInsights: List<QueryInsight<PsiElement, NotUsingFilters>>
+    ) {
+        val probe by service<InspectionStatusChangedProbe>()
+        probe.finishedProcessingInspections(
+            TelemetryEvent.InspectionStatusChangeEvent.InspectionType.QUERY_NOT_COVERED_BY_INDEX,
+            queryInsights,
+        )
+    }
+}

--- a/packages/jetbrains-plugin/src/main/resources/META-INF/plugin.xml
+++ b/packages/jetbrains-plugin/src/main/resources/META-INF/plugin.xml
@@ -86,6 +86,19 @@
             implementationClass="com.mongodb.jbplugin.inspections.performance.MongoDbQueryNotUsingIndexEffectivelyGlobalTool"
         />
 
+        <externalAnnotator language="JAVA" implementationClass="com.mongodb.jbplugin.inspections.performance.MongoDbQueryNotUsingFilters" />
+        <globalInspection
+            groupPath="MongoDB"
+            groupBundle="messages.SidePanelBundle"
+            groupKey="inspection.category.performance"
+            bundle="messages.InspectionsAndInlaysBundle"
+            key="query-not-using-filters"
+            shortName="NotUsingFilters"
+            enabledByDefault="true"
+            language="JAVA"
+            implementationClass="com.mongodb.jbplugin.inspections.performance.MongoDbQueryNotUsingFiltersGlobalTool"
+        />
+
         <!-- Correctness Inspections -->
         <externalAnnotator language="JAVA" implementationClass="com.mongodb.jbplugin.inspections.correctness.MongoDbFieldDoesNotExist" />
         <globalInspection

--- a/packages/jetbrains-plugin/src/main/resources/messages/InspectionsAndInlaysBundle.properties
+++ b/packages/jetbrains-plugin/src/main/resources/messages/InspectionsAndInlaysBundle.properties
@@ -15,7 +15,7 @@ inlay.indexing.not-run.text=Dynamic Query
 inlay.indexing.not-run.tooltip=Could not analyse the query because it's using unsupported features by the plugin.
 
 inlay.query.not-using-filters.text=No Filters
-inlay.query.not-using-filters.tooltip=This query lacks filters and will scan the entire collection, which can cause severe performance issues. Either add a filter/match to your query or process the results as a stream/cursor.
+inlay.query.not-using-filters.tooltip=This query lacks filters and will scan the entire collection, which can cause severe performance issues. Ensure that you have a filter/match in your query.
 
 ##########################################################################
 ## Performance ###########################################################

--- a/packages/jetbrains-plugin/src/main/resources/messages/InspectionsAndInlaysBundle.properties
+++ b/packages/jetbrains-plugin/src/main/resources/messages/InspectionsAndInlaysBundle.properties
@@ -14,6 +14,9 @@ inlay.indexing.ineffective-index-scan.text=Ineffective Index Scan
 inlay.indexing.not-run.text=Dynamic Query
 inlay.indexing.not-run.tooltip=Could not analyse the query because it's using unsupported features by the plugin.
 
+inlay.query.not-using-filters.text=No Filters
+inlay.query.not-using-filters.tooltip=This query lacks filters and will scan the entire collection, which can cause severe performance issues. Either add a filter/match to your query or process the results as a stream/cursor.
+
 ##########################################################################
 ## Performance ###########################################################
 ##########################################################################
@@ -23,6 +26,9 @@ insight.not-using-index=Query does not use an index.
 
 query-not-using-index-effectively=Query not using an index effectively
 insight.not-using-index-effectively=Query does not use an index effectively.
+
+query-not-using-filters=Query lacks filters, may fetch the entire collection
+insight.not-using-filters=Query lacks filters, may fetch the entire collection.
 
 ##########################################################################
 ## Correctness ###########################################################

--- a/packages/jetbrains-plugin/src/main/resources/messages/SidePanelBundle.properties
+++ b/packages/jetbrains-plugin/src/main/resources/messages/SidePanelBundle.properties
@@ -40,6 +40,7 @@ side-panel.scope.no-insights-message.generic.text=No insights found for the curr
 inspection.category.performance=Performance Warnings
 insight.not-using-index=Query not using an index
 insight.not-using-index-effectively=Query not using an index effectively
+insight.not-using-filters=Query lacks filters, may fetch the entire collection
 
 inspection.category.correctness=Correctness Warnings
 insight.field-does-not-exist=Field "{0}" does not seem to exist in collection.

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inlays/MongoDbQueryIndexStatusInlayTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inlays/MongoDbQueryIndexStatusInlayTest.kt
@@ -66,7 +66,7 @@ class MongoDbQueryIndexStatusInlayTest {
     public FindIterable<Document> exampleFind() {
         <hint text="[<image> Missing Index]"/>client.getDatabase("myDatabase")
                 .getCollection("myCollection")
-                .find();
+                .find(eq("name", "test"));
     }
         """,
     )
@@ -86,9 +86,31 @@ class MongoDbQueryIndexStatusInlayTest {
     @ParsingTest(
         value = """
     public FindIterable<Document> exampleFind() {
-        <hint text="[<image> Index Scan]"/>client.getDatabase("myDatabase")
+        <hint text="[<image> No Filters]"/>client.getDatabase("myDatabase")
                 .getCollection("myCollection")
                 .find();
+    }
+        """,
+    )
+    fun `shows a no filters inlay`(
+        fixture: CodeInsightTestFixture,
+    ) = runTest {
+        val (_, readModel) = fixture.setupConnection()
+        fixture.specifyDialect(JavaDriverDialect)
+
+        readModel.whenListDatabases("myDatabase")
+        readModel.whenListCollections("myCollection")
+        readModel.whenExplainQuery(ExplainPlan.IndexScan("my_index"))
+
+        testIndexInlay(fixture)
+    }
+
+    @ParsingTest(
+        value = """
+    public FindIterable<Document> exampleFind() {
+        <hint text="[<image> Index Scan]"/>client.getDatabase("myDatabase")
+                .getCollection("myCollection")
+                .find(eq("name", "test"));
     }
         """,
     )
@@ -110,7 +132,7 @@ class MongoDbQueryIndexStatusInlayTest {
     public FindIterable<Document> exampleFind() {
         <hint text="[<image> Ineffective Index Scan]"/>client.getDatabase("myDatabase")
                 .getCollection("myCollection")
-                .find();
+                .find(eq("name", "test"));
     }
         """,
     )
@@ -132,7 +154,7 @@ class MongoDbQueryIndexStatusInlayTest {
     public FindIterable<Document> exampleFind() {
         <hint text="[<image> Dynamic Query]"/>client.getDatabase("myDatabase")
                 .getCollection("myCollection")
-                .find();
+                .find(eq("name", "test"));
     }
         """,
     )

--- a/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/QueryInsight.kt
+++ b/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/QueryInsight.kt
@@ -6,6 +6,7 @@ import com.mongodb.jbplugin.linting.Inspection.FieldDoesNotExist
 import com.mongodb.jbplugin.linting.Inspection.InvalidProjection
 import com.mongodb.jbplugin.linting.Inspection.NoCollectionSpecified
 import com.mongodb.jbplugin.linting.Inspection.NoDatabaseInferred
+import com.mongodb.jbplugin.linting.Inspection.NotUsingFilters
 import com.mongodb.jbplugin.linting.Inspection.NotUsingIndex
 import com.mongodb.jbplugin.linting.Inspection.NotUsingIndexEffectively
 import com.mongodb.jbplugin.linting.Inspection.TypeMismatch
@@ -56,6 +57,12 @@ sealed interface Inspection {
 
     data object NotUsingIndexEffectively : Inspection {
         override val primaryAction = CreateIndexSuggestionScript
+        override val secondaryActions = emptyArray<InspectionAction>()
+        override val category = PERFORMANCE
+    }
+
+    data object NotUsingFilters : Inspection {
+        override val primaryAction = NoAction
         override val secondaryActions = emptyArray<InspectionAction>()
         override val category = PERFORMANCE
     }
@@ -130,6 +137,16 @@ data class QueryInsight<S, I : Inspection>(
                 description = "insight.not-using-index-effectively",
                 descriptionArguments = emptyList(),
                 inspection = NotUsingIndexEffectively
+            )
+        }
+
+        fun <S> notUsingFilters(query: Node<S>): QueryInsight<S, NotUsingFilters> {
+            return QueryInsight(
+                query = query,
+                source = query.source,
+                description = "insight.not-using-filters",
+                descriptionArguments = emptyList(),
+                inspection = NotUsingFilters
             )
         }
 

--- a/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/performance/QueryNotUsingFiltersInspection.kt
+++ b/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/performance/QueryNotUsingFiltersInspection.kt
@@ -1,0 +1,29 @@
+package com.mongodb.jbplugin.linting.performance
+
+import com.mongodb.jbplugin.linting.Inspection.NotUsingFilters
+import com.mongodb.jbplugin.linting.QueryInsight
+import com.mongodb.jbplugin.linting.QueryInsightsHolder
+import com.mongodb.jbplugin.linting.QueryInspection
+import com.mongodb.jbplugin.mql.Node
+import com.mongodb.jbplugin.mql.adt.Either
+import com.mongodb.jbplugin.mql.parser.components.allFiltersRecursively
+import com.mongodb.jbplugin.mql.parser.parse
+
+class QueryNotUsingFiltersInspection : QueryInspection<Unit, NotUsingFilters> {
+    override suspend fun <Source> run(
+        query: Node<Source>,
+        holder: QueryInsightsHolder<Source, NotUsingFilters>,
+        settings: Unit
+    ) {
+        val queryHasNoFilters = when (
+            val allFilters = allFiltersRecursively<Source>().parse(query)
+        ) {
+            is Either.Left -> true
+            is Either.Right -> allFilters.value.isEmpty()
+        }
+
+        if (queryHasNoFilters) {
+            holder.register(QueryInsight.notUsingFilters(query))
+        }
+    }
+}

--- a/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/performance/QueryNotUsingIndexEffectivelyInspection.kt
+++ b/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/performance/QueryNotUsingIndexEffectivelyInspection.kt
@@ -14,6 +14,7 @@ import com.mongodb.jbplugin.mql.adt.Either
 import com.mongodb.jbplugin.mql.components.HasExplain
 import com.mongodb.jbplugin.mql.components.HasExplain.ExplainPlanType
 import com.mongodb.jbplugin.mql.components.IsCommand
+import com.mongodb.jbplugin.mql.parser.components.allFiltersRecursively
 import com.mongodb.jbplugin.mql.parser.components.knownCollection
 import com.mongodb.jbplugin.mql.parser.filter
 import com.mongodb.jbplugin.mql.parser.parse
@@ -33,7 +34,15 @@ class QueryNotUsingIndexEffectivelyInspection<D> : QueryInspection<
         holder: QueryInsightsHolder<Source, NotUsingIndexEffectively>,
         settings: QueryNotUsingIndexEffectivelyInspectionSettings<D>
     ) {
-        if (query.component<IsCommand>()?.type?.usesIndexes == false) {
+        val commandDoesNotUseIndexes = query.component<IsCommand>()?.type?.usesIndexes == false
+        val queryHasNoFilters = when (
+            val allFilters = allFiltersRecursively<Source>().parse(query)
+        ) {
+            is Either.Left -> true
+            is Either.Right -> allFilters.value.isEmpty()
+        }
+
+        if (commandDoesNotUseIndexes || queryHasNoFilters) {
             return
         }
 

--- a/packages/mongodb-mql-engines/src/test/kotlin/com/mongodb/jbplugin/linting/performance/QueryNotUsingFiltersInspectionTest.kt
+++ b/packages/mongodb-mql-engines/src/test/kotlin/com/mongodb/jbplugin/linting/performance/QueryNotUsingFiltersInspectionTest.kt
@@ -1,0 +1,24 @@
+package com.mongodb.jbplugin.linting.performance
+
+import com.mongodb.jbplugin.linting.Inspection.NotUsingFilters
+import com.mongodb.jbplugin.linting.QueryInspectionTest
+import com.mongodb.jbplugin.mql.components.HasFilter
+import org.junit.Test
+
+class QueryNotUsingFiltersInspectionTest : QueryInspectionTest<NotUsingFilters> {
+    @Test
+    fun `warns when query does not any filters`() = runInspectionTest {
+        val query = query.with(HasFilter<Unit>(emptyList()))
+        val inspection = QueryNotUsingFiltersInspection()
+        inspection.run(query, holder, Unit)
+        onInsight(0).assertInsightDescriptionIs("insight.not-using-filters")
+    }
+
+    @Test
+    fun `does not warn when query has filters`() = runInspectionTest {
+        val query = query.with(commonFilter)
+        val inspection = QueryNotUsingFiltersInspection()
+        inspection.run(query, holder, Unit)
+        assertNoInsights()
+    }
+}

--- a/packages/mongodb-mql-engines/src/test/kotlin/com/mongodb/jbplugin/linting/performance/QueryNotUsingIndexInspectionEffectivelyTest.kt
+++ b/packages/mongodb-mql-engines/src/test/kotlin/com/mongodb/jbplugin/linting/performance/QueryNotUsingIndexInspectionEffectivelyTest.kt
@@ -6,6 +6,7 @@ import com.mongodb.jbplugin.linting.QueryInspectionTest
 import com.mongodb.jbplugin.mql.Namespace
 import com.mongodb.jbplugin.mql.components.HasCollectionReference
 import com.mongodb.jbplugin.mql.components.HasExplain.ExplainPlanType.SAFE
+import com.mongodb.jbplugin.mql.components.HasFilter
 import org.junit.jupiter.api.Test
 
 class QueryNotUsingIndexInspectionEffectivelyTest : QueryInspectionTest<NotUsingIndexEffectively> {
@@ -20,7 +21,7 @@ class QueryNotUsingIndexInspectionEffectivelyTest : QueryInspectionTest<NotUsing
             HasCollectionReference(
                 HasCollectionReference.Known(null, null, namespace)
             )
-        )
+        ).with(commonFilter)
 
         val inspection = QueryNotUsingIndexEffectivelyInspection<Unit>()
         inspection.run(query, holder, QueryNotUsingIndexEffectivelyInspectionSettings(Unit, readModelProvider, SAFE))
@@ -39,7 +40,7 @@ class QueryNotUsingIndexInspectionEffectivelyTest : QueryInspectionTest<NotUsing
             HasCollectionReference(
                 HasCollectionReference.Known(null, null, namespace)
             )
-        )
+        ).with(commonFilter)
 
         val inspection = QueryNotUsingIndexEffectivelyInspection<Unit>()
         inspection.run(query, holder, QueryNotUsingIndexEffectivelyInspectionSettings(Unit, readModelProvider, SAFE))
@@ -58,7 +59,7 @@ class QueryNotUsingIndexInspectionEffectivelyTest : QueryInspectionTest<NotUsing
             HasCollectionReference(
                 HasCollectionReference.Known(null, null, namespace)
             )
-        )
+        ).with(commonFilter)
 
         val inspection = QueryNotUsingIndexEffectivelyInspection<Unit>()
         inspection.run(query, holder, QueryNotUsingIndexEffectivelyInspectionSettings(Unit, readModelProvider, SAFE))
@@ -77,7 +78,7 @@ class QueryNotUsingIndexInspectionEffectivelyTest : QueryInspectionTest<NotUsing
             HasCollectionReference(
                 HasCollectionReference.Known(null, null, namespace)
             )
-        )
+        ).with(commonFilter)
 
         val inspection = QueryNotUsingIndexEffectivelyInspection<Unit>()
         inspection.run(query, holder, QueryNotUsingIndexEffectivelyInspectionSettings(Unit, readModelProvider, SAFE))
@@ -96,7 +97,7 @@ class QueryNotUsingIndexInspectionEffectivelyTest : QueryInspectionTest<NotUsing
             HasCollectionReference(
                 HasCollectionReference.Known(null, null, namespace)
             )
-        )
+        ).with(commonFilter)
 
         val inspection = QueryNotUsingIndexEffectivelyInspection<Unit>()
         inspection.run(query, holder, QueryNotUsingIndexEffectivelyInspectionSettings(Unit, readModelProvider, SAFE))
@@ -115,7 +116,26 @@ class QueryNotUsingIndexInspectionEffectivelyTest : QueryInspectionTest<NotUsing
             HasCollectionReference(
                 HasCollectionReference.Known(null, null, namespace)
             )
-        )
+        ).with(commonFilter)
+
+        val inspection = QueryNotUsingIndexEffectivelyInspection<Unit>()
+        inspection.run(query, holder, QueryNotUsingIndexEffectivelyInspectionSettings(Unit, readModelProvider, SAFE))
+
+        assertNoInsights()
+    }
+
+    @Test
+    fun `does not warn when query has no filters`() = runInspectionTest {
+        val namespace = Namespace("database", "collection")
+        whenDatabasesAre(listOf("database"))
+        whenCollectionsAre(listOf("collection"))
+        whenExplainPlanIs(ExplainPlan.IneffectiveIndexUsage(""))
+
+        val query = query.with(
+            HasCollectionReference(
+                HasCollectionReference.Known(null, null, namespace)
+            )
+        ).with(HasFilter<Unit>(emptyList()))
 
         val inspection = QueryNotUsingIndexEffectivelyInspection<Unit>()
         inspection.run(query, holder, QueryNotUsingIndexEffectivelyInspectionSettings(Unit, readModelProvider, SAFE))

--- a/packages/mongodb-mql-engines/src/test/kotlin/com/mongodb/jbplugin/linting/performance/QueryNotUsingIndexInspectionTest.kt
+++ b/packages/mongodb-mql-engines/src/test/kotlin/com/mongodb/jbplugin/linting/performance/QueryNotUsingIndexInspectionTest.kt
@@ -3,10 +3,39 @@ package com.mongodb.jbplugin.linting.performance
 import com.mongodb.jbplugin.accessadapter.slice.ExplainPlan
 import com.mongodb.jbplugin.linting.Inspection.NotUsingIndex
 import com.mongodb.jbplugin.linting.QueryInspectionTest
+import com.mongodb.jbplugin.mql.BsonString
 import com.mongodb.jbplugin.mql.Namespace
+import com.mongodb.jbplugin.mql.Node
 import com.mongodb.jbplugin.mql.components.HasCollectionReference
 import com.mongodb.jbplugin.mql.components.HasExplain.ExplainPlanType.SAFE
+import com.mongodb.jbplugin.mql.components.HasFieldReference
+import com.mongodb.jbplugin.mql.components.HasFilter
+import com.mongodb.jbplugin.mql.components.HasValueReference
 import org.junit.jupiter.api.Test
+
+val commonFilter = HasFilter(
+    children = listOf(
+        Node(
+            source = null,
+            components = listOf(
+                HasFieldReference(
+                    HasFieldReference.FromSchema(
+                        source = null,
+                        fieldName = "field",
+                        displayName = "field",
+                    )
+                ),
+                HasValueReference(
+                    HasValueReference.Constant(
+                        source = null,
+                        value = "value",
+                        type = BsonString,
+                    )
+                )
+            )
+        )
+    )
+)
 
 class QueryNotUsingIndexInspectionTest : QueryInspectionTest<NotUsingIndex> {
     @Test
@@ -19,8 +48,8 @@ class QueryNotUsingIndexInspectionTest : QueryInspectionTest<NotUsingIndex> {
         val query = query.with(
             HasCollectionReference(
                 HasCollectionReference.Known(null, null, namespace)
-            )
-        )
+            ),
+        ).with(commonFilter)
 
         val inspection = QueryNotUsingIndexInspection<Unit>()
         inspection.run(query, holder, QueryNotUsingIndexInspectionSettings(Unit, readModelProvider, SAFE))
@@ -39,7 +68,7 @@ class QueryNotUsingIndexInspectionTest : QueryInspectionTest<NotUsingIndex> {
             HasCollectionReference(
                 HasCollectionReference.Known(null, null, namespace)
             )
-        )
+        ).with(commonFilter)
 
         val inspection = QueryNotUsingIndexInspection<Unit>()
         inspection.run(query, holder, QueryNotUsingIndexInspectionSettings(Unit, readModelProvider, SAFE))
@@ -58,7 +87,7 @@ class QueryNotUsingIndexInspectionTest : QueryInspectionTest<NotUsingIndex> {
             HasCollectionReference(
                 HasCollectionReference.Known(null, null, namespace)
             )
-        )
+        ).with(commonFilter)
 
         val inspection = QueryNotUsingIndexInspection<Unit>()
         inspection.run(query, holder, QueryNotUsingIndexInspectionSettings(Unit, readModelProvider, SAFE))
@@ -77,7 +106,7 @@ class QueryNotUsingIndexInspectionTest : QueryInspectionTest<NotUsingIndex> {
             HasCollectionReference(
                 HasCollectionReference.Known(null, null, namespace)
             )
-        )
+        ).with(commonFilter)
 
         val inspection = QueryNotUsingIndexInspection<Unit>()
         inspection.run(query, holder, QueryNotUsingIndexInspectionSettings(Unit, readModelProvider, SAFE))
@@ -96,7 +125,7 @@ class QueryNotUsingIndexInspectionTest : QueryInspectionTest<NotUsingIndex> {
             HasCollectionReference(
                 HasCollectionReference.Known(null, null, namespace)
             )
-        )
+        ).with(commonFilter)
 
         val inspection = QueryNotUsingIndexInspection<Unit>()
         inspection.run(query, holder, QueryNotUsingIndexInspectionSettings(Unit, readModelProvider, SAFE))
@@ -115,7 +144,26 @@ class QueryNotUsingIndexInspectionTest : QueryInspectionTest<NotUsingIndex> {
             HasCollectionReference(
                 HasCollectionReference.Known(null, null, namespace)
             )
-        )
+        ).with(commonFilter)
+
+        val inspection = QueryNotUsingIndexInspection<Unit>()
+        inspection.run(query, holder, QueryNotUsingIndexInspectionSettings(Unit, readModelProvider, SAFE))
+
+        assertNoInsights()
+    }
+
+    @Test
+    fun `does not warn when query has no filters`() = runInspectionTest {
+        val namespace = Namespace("database", "collection")
+        whenDatabasesAre(listOf("database"))
+        whenCollectionsAre(listOf("collection"))
+        whenExplainPlanIs(ExplainPlan.CollectionScan)
+
+        val query = query.with(
+            HasCollectionReference(
+                HasCollectionReference.Known(null, null, namespace)
+            )
+        ).with(HasFilter<Unit>(emptyList()))
 
         val inspection = QueryNotUsingIndexInspection<Unit>()
         inspection.run(query, holder, QueryNotUsingIndexInspectionSettings(Unit, readModelProvider, SAFE))


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER-IF-ANY>

  eg. fix(type-hint): infer type of a constant for type checking INTELLIJ-1111
-->

## Description

When a query has no filter, it does not make much sense for us to warn about missing or ineffective index usage. In this PR, we add another check of looking for filters in the query before running the NotUsingIndex and IneffectiveIndexUsage inspections.

Additionally, for queries that do not have any filters, we will now warn about such usage with an insight with title - "Query lacks filters, may fetch the entire collection", and also an inlay called - "No Filters"

<!--- Describe your changes in detail so reviewers have enough content on what this PR aims to achieve -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist

- [x] New tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
- [ ] Changelog is updated accordingly.
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement).

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->