### PR TITLE
fix: show no index warnings when a query has no filters INTELLIJ-360

### DIFF
--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/CachedQueryService.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/CachedQueryService.kt
@@ -108,10 +108,9 @@ class CachedQueryService(
             }
 
             attachment.putUserData(queryCacheKey, cachedValue)
-            return decorateWithMetadata(
-                dataSource,
-                attachment.getUserData(queryCacheKey)!!.value
-            )
+            return attachment.getUserData(queryCacheKey)?.value?.let {
+                decorateWithMetadata(dataSource, it)
+            }
         } catch (pce: ProcessCanceledException) {
             throw pce
         } catch (ex: Exception) {

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/inspections/AbstractMongoDbInspectionBridge.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/inspections/AbstractMongoDbInspectionBridge.kt
@@ -64,6 +64,8 @@ abstract class AbstractMongoDbInspectionGlobalTool(
     // in plugin.xml.
     override fun getShortName(): String = inspection.javaClass.simpleName
 
+    override fun getStaticDescription(): String? = inspection.javaClass.simpleName
+
     override fun worksInBatchModeOnly() = false
 
     companion object {

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inlays/MongoDbQueryIndexStatusInlayTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/inlays/MongoDbQueryIndexStatusInlayTest.kt
@@ -66,7 +66,7 @@ class MongoDbQueryIndexStatusInlayTest {
     public FindIterable<Document> exampleFind() {
         <hint text="[<image> Missing Index]"/>client.getDatabase("myDatabase")
                 .getCollection("myCollection")
-                .find();
+                .find(eq("name", "test"));
     }
         """,
     )
@@ -88,7 +88,7 @@ class MongoDbQueryIndexStatusInlayTest {
     public FindIterable<Document> exampleFind() {
         <hint text="[<image> Index Scan]"/>client.getDatabase("myDatabase")
                 .getCollection("myCollection")
-                .find();
+                .find(eq("name", "test"));
     }
         """,
     )
@@ -110,7 +110,7 @@ class MongoDbQueryIndexStatusInlayTest {
     public FindIterable<Document> exampleFind() {
         <hint text="[<image> Ineffective Index Scan]"/>client.getDatabase("myDatabase")
                 .getCollection("myCollection")
-                .find();
+                .find(eq("name", "test"));
     }
         """,
     )
@@ -132,7 +132,7 @@ class MongoDbQueryIndexStatusInlayTest {
     public FindIterable<Document> exampleFind() {
         <hint text="[<image> Dynamic Query]"/>client.getDatabase("myDatabase")
                 .getCollection("myCollection")
-                .find();
+                .find(eq("name", "test"));
     }
         """,
     )

--- a/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/performance/QueryNotUsingIndexEffectivelyInspection.kt
+++ b/packages/mongodb-mql-engines/src/main/kotlin/com/mongodb/jbplugin/linting/performance/QueryNotUsingIndexEffectivelyInspection.kt
@@ -14,6 +14,7 @@ import com.mongodb.jbplugin.mql.adt.Either
 import com.mongodb.jbplugin.mql.components.HasExplain
 import com.mongodb.jbplugin.mql.components.HasExplain.ExplainPlanType
 import com.mongodb.jbplugin.mql.components.IsCommand
+import com.mongodb.jbplugin.mql.parser.components.allFiltersRecursively
 import com.mongodb.jbplugin.mql.parser.components.knownCollection
 import com.mongodb.jbplugin.mql.parser.filter
 import com.mongodb.jbplugin.mql.parser.parse
@@ -33,7 +34,15 @@ class QueryNotUsingIndexEffectivelyInspection<D> : QueryInspection<
         holder: QueryInsightsHolder<Source, NotUsingIndexEffectively>,
         settings: QueryNotUsingIndexEffectivelyInspectionSettings<D>
     ) {
-        if (query.component<IsCommand>()?.type?.usesIndexes == false) {
+        val commandDoesNotUseIndexes = query.component<IsCommand>()?.type?.usesIndexes == false
+        val queryHasNoFilters = when (
+            val allFilters = allFiltersRecursively<Source>().parse(query)
+        ) {
+            is Either.Left -> true
+            is Either.Right -> allFilters.value.isEmpty()
+        }
+
+        if (commandDoesNotUseIndexes || queryHasNoFilters) {
             return
         }
 

--- a/packages/mongodb-mql-engines/src/test/kotlin/com/mongodb/jbplugin/linting/performance/QueryNotUsingIndexInspectionEffectivelyTest.kt
+++ b/packages/mongodb-mql-engines/src/test/kotlin/com/mongodb/jbplugin/linting/performance/QueryNotUsingIndexInspectionEffectivelyTest.kt
@@ -6,6 +6,7 @@ import com.mongodb.jbplugin.linting.QueryInspectionTest
 import com.mongodb.jbplugin.mql.Namespace
 import com.mongodb.jbplugin.mql.components.HasCollectionReference
 import com.mongodb.jbplugin.mql.components.HasExplain.ExplainPlanType.SAFE
+import com.mongodb.jbplugin.mql.components.HasFilter
 import org.junit.jupiter.api.Test
 
 class QueryNotUsingIndexInspectionEffectivelyTest : QueryInspectionTest<NotUsingIndexEffectively> {
@@ -20,7 +21,7 @@ class QueryNotUsingIndexInspectionEffectivelyTest : QueryInspectionTest<NotUsing
             HasCollectionReference(
                 HasCollectionReference.Known(null, null, namespace)
             )
-        )
+        ).with(commonFilter)
 
         val inspection = QueryNotUsingIndexEffectivelyInspection<Unit>()
         inspection.run(query, holder, QueryNotUsingIndexEffectivelyInspectionSettings(Unit, readModelProvider, SAFE))
@@ -39,7 +40,7 @@ class QueryNotUsingIndexInspectionEffectivelyTest : QueryInspectionTest<NotUsing
             HasCollectionReference(
                 HasCollectionReference.Known(null, null, namespace)
             )
-        )
+        ).with(commonFilter)
 
         val inspection = QueryNotUsingIndexEffectivelyInspection<Unit>()
         inspection.run(query, holder, QueryNotUsingIndexEffectivelyInspectionSettings(Unit, readModelProvider, SAFE))
@@ -58,7 +59,7 @@ class QueryNotUsingIndexInspectionEffectivelyTest : QueryInspectionTest<NotUsing
             HasCollectionReference(
                 HasCollectionReference.Known(null, null, namespace)
             )
-        )
+        ).with(commonFilter)
 
         val inspection = QueryNotUsingIndexEffectivelyInspection<Unit>()
         inspection.run(query, holder, QueryNotUsingIndexEffectivelyInspectionSettings(Unit, readModelProvider, SAFE))
@@ -77,7 +78,7 @@ class QueryNotUsingIndexInspectionEffectivelyTest : QueryInspectionTest<NotUsing
             HasCollectionReference(
                 HasCollectionReference.Known(null, null, namespace)
             )
-        )
+        ).with(commonFilter)
 
         val inspection = QueryNotUsingIndexEffectivelyInspection<Unit>()
         inspection.run(query, holder, QueryNotUsingIndexEffectivelyInspectionSettings(Unit, readModelProvider, SAFE))
@@ -96,7 +97,7 @@ class QueryNotUsingIndexInspectionEffectivelyTest : QueryInspectionTest<NotUsing
             HasCollectionReference(
                 HasCollectionReference.Known(null, null, namespace)
             )
-        )
+        ).with(commonFilter)
 
         val inspection = QueryNotUsingIndexEffectivelyInspection<Unit>()
         inspection.run(query, holder, QueryNotUsingIndexEffectivelyInspectionSettings(Unit, readModelProvider, SAFE))
@@ -115,7 +116,26 @@ class QueryNotUsingIndexInspectionEffectivelyTest : QueryInspectionTest<NotUsing
             HasCollectionReference(
                 HasCollectionReference.Known(null, null, namespace)
             )
-        )
+        ).with(commonFilter)
+
+        val inspection = QueryNotUsingIndexEffectivelyInspection<Unit>()
+        inspection.run(query, holder, QueryNotUsingIndexEffectivelyInspectionSettings(Unit, readModelProvider, SAFE))
+
+        assertNoInsights()
+    }
+
+    @Test
+    fun `does not warn when query has no filters`() = runInspectionTest {
+        val namespace = Namespace("database", "collection")
+        whenDatabasesAre(listOf("database"))
+        whenCollectionsAre(listOf("collection"))
+        whenExplainPlanIs(ExplainPlan.IneffectiveIndexUsage(""))
+
+        val query = query.with(
+            HasCollectionReference(
+                HasCollectionReference.Known(null, null, namespace)
+            )
+        ).with(HasFilter<Unit>(emptyList()))
 
         val inspection = QueryNotUsingIndexEffectivelyInspection<Unit>()
         inspection.run(query, holder, QueryNotUsingIndexEffectivelyInspectionSettings(Unit, readModelProvider, SAFE))

--- a/packages/mongodb-mql-engines/src/test/kotlin/com/mongodb/jbplugin/linting/performance/QueryNotUsingIndexInspectionTest.kt
+++ b/packages/mongodb-mql-engines/src/test/kotlin/com/mongodb/jbplugin/linting/performance/QueryNotUsingIndexInspectionTest.kt
@@ -3,10 +3,39 @@ package com.mongodb.jbplugin.linting.performance
 import com.mongodb.jbplugin.accessadapter.slice.ExplainPlan
 import com.mongodb.jbplugin.linting.Inspection.NotUsingIndex
 import com.mongodb.jbplugin.linting.QueryInspectionTest
+import com.mongodb.jbplugin.mql.BsonString
 import com.mongodb.jbplugin.mql.Namespace
+import com.mongodb.jbplugin.mql.Node
 import com.mongodb.jbplugin.mql.components.HasCollectionReference
 import com.mongodb.jbplugin.mql.components.HasExplain.ExplainPlanType.SAFE
+import com.mongodb.jbplugin.mql.components.HasFieldReference
+import com.mongodb.jbplugin.mql.components.HasFilter
+import com.mongodb.jbplugin.mql.components.HasValueReference
 import org.junit.jupiter.api.Test
+
+val commonFilter = HasFilter(
+    children = listOf(
+        Node(
+            source = null,
+            components = listOf(
+                HasFieldReference(
+                    HasFieldReference.FromSchema(
+                        source = null,
+                        fieldName = "field",
+                        displayName = "field",
+                    )
+                ),
+                HasValueReference(
+                    HasValueReference.Constant(
+                        source = null,
+                        value = "value",
+                        type = BsonString,
+                    )
+                )
+            )
+        )
+    )
+)
 
 class QueryNotUsingIndexInspectionTest : QueryInspectionTest<NotUsingIndex> {
     @Test
@@ -19,8 +48,8 @@ class QueryNotUsingIndexInspectionTest : QueryInspectionTest<NotUsingIndex> {
         val query = query.with(
             HasCollectionReference(
                 HasCollectionReference.Known(null, null, namespace)
-            )
-        )
+            ),
+        ).with(commonFilter)
 
         val inspection = QueryNotUsingIndexInspection<Unit>()
         inspection.run(query, holder, QueryNotUsingIndexInspectionSettings(Unit, readModelProvider, SAFE))
@@ -39,7 +68,7 @@ class QueryNotUsingIndexInspectionTest : QueryInspectionTest<NotUsingIndex> {
             HasCollectionReference(
                 HasCollectionReference.Known(null, null, namespace)
             )
-        )
+        ).with(commonFilter)
 
         val inspection = QueryNotUsingIndexInspection<Unit>()
         inspection.run(query, holder, QueryNotUsingIndexInspectionSettings(Unit, readModelProvider, SAFE))
@@ -58,7 +87,7 @@ class QueryNotUsingIndexInspectionTest : QueryInspectionTest<NotUsingIndex> {
             HasCollectionReference(
                 HasCollectionReference.Known(null, null, namespace)
             )
-        )
+        ).with(commonFilter)
 
         val inspection = QueryNotUsingIndexInspection<Unit>()
         inspection.run(query, holder, QueryNotUsingIndexInspectionSettings(Unit, readModelProvider, SAFE))
@@ -77,7 +106,7 @@ class QueryNotUsingIndexInspectionTest : QueryInspectionTest<NotUsingIndex> {
             HasCollectionReference(
                 HasCollectionReference.Known(null, null, namespace)
             )
-        )
+        ).with(commonFilter)
 
         val inspection = QueryNotUsingIndexInspection<Unit>()
         inspection.run(query, holder, QueryNotUsingIndexInspectionSettings(Unit, readModelProvider, SAFE))
@@ -96,7 +125,7 @@ class QueryNotUsingIndexInspectionTest : QueryInspectionTest<NotUsingIndex> {
             HasCollectionReference(
                 HasCollectionReference.Known(null, null, namespace)
             )
-        )
+        ).with(commonFilter)
 
         val inspection = QueryNotUsingIndexInspection<Unit>()
         inspection.run(query, holder, QueryNotUsingIndexInspectionSettings(Unit, readModelProvider, SAFE))
@@ -115,7 +144,26 @@ class QueryNotUsingIndexInspectionTest : QueryInspectionTest<NotUsingIndex> {
             HasCollectionReference(
                 HasCollectionReference.Known(null, null, namespace)
             )
-        )
+        ).with(commonFilter)
+
+        val inspection = QueryNotUsingIndexInspection<Unit>()
+        inspection.run(query, holder, QueryNotUsingIndexInspectionSettings(Unit, readModelProvider, SAFE))
+
+        assertNoInsights()
+    }
+
+    @Test
+    fun `does not warn when query has no filters`() = runInspectionTest {
+        val namespace = Namespace("database", "collection")
+        whenDatabasesAre(listOf("database"))
+        whenCollectionsAre(listOf("collection"))
+        whenExplainPlanIs(ExplainPlan.CollectionScan)
+
+        val query = query.with(
+            HasCollectionReference(
+                HasCollectionReference.Known(null, null, namespace)
+            )
+        ).with(HasFilter<Unit>(emptyList()))
 
         val inspection = QueryNotUsingIndexInspection<Unit>()
         inspection.run(query, holder, QueryNotUsingIndexInspectionSettings(Unit, readModelProvider, SAFE))


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER-IF-ANY>

  eg. fix(type-hint): infer type of a constant for type checking INTELLIJ-1111
-->

## Description
When a query has no filter or, we were unable to detect filters in the query, it does not make much sense for us to warn about missing or ineffective index usage. In this PR, we add another check of looking for filters in the query before running the NotUsingIndex and IneffectiveIndexUsage inspections.

<!--- Describe your changes in detail so reviewers have enough content on what this PR aims to achieve -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist

- [ ] New tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
- [ ] Changelog is updated accordingly.
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement).

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->