### PR TITLE
fix: enforce the HasLimit req by Explain

### DIFF
--- a/packages/mongodb-access-adapter/src/main/kotlin/com/mongodb/jbplugin/accessadapter/slice/ExplainQuery.kt
+++ b/packages/mongodb-access-adapter/src/main/kotlin/com/mongodb/jbplugin/accessadapter/slice/ExplainQuery.kt
@@ -69,7 +69,7 @@ data class ExplainQuery(
             val explainPlanQueryResult = runCatching {
                 // Ensuring that the query at-least has a limit if it doesn't already because
                 // the explain is run automatically
-                from.runQuery(query.with(HasLimit(1)), Map::class, queryContext)
+                from.runQuery(query.withReplaced(HasLimit(1)), Map::class, queryContext)
             }.getOrNull() ?: return ExplainQuery(ExplainPlan.NotRun)
 
             val explainPlanDoc =

--- a/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/Node.kt
+++ b/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/Node.kt
@@ -72,6 +72,20 @@ data class Node<S>(
         return copy(components = components + component)
     }
 
+    fun withReplaced(component: Component): Node<S> {
+        val componentClass = component::class
+        val newComponents = components.map {
+            if (it::class == componentClass) component else it
+        }
+
+        val replaced = newComponents.any { it === component }
+        return if (replaced) {
+            copy(components = newComponents)
+        } else {
+            copy(components = components + component)
+        }
+    }
+
     fun componentsWithChildren(): List<HasChildren<S>> = components.filterIsInstance<HasChildren<S>>()
 
     inline fun <reified C : Component> hasComponent(): Boolean = component<C>() != null


### PR DESCRIPTION
ExplainQuery was adding HasLimit component with n=1 but when the query already had a HasLimit component (parsed from the Java code), this newly added component was getting ignored in the
DataGripMongoDbDriver.runQuery and instead of returning an object we were returning a list, which was later causing an exception in ExplainQuery itself.

I don't have a stack trace but it should be easy to reproduce by having a query with limit and letting the Index inspection run on it. The exception should be visible in debug console.

This commit fixes that by replacing the existing limit if any which should be safe to do particularly for ExplainQuery.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER-IF-ANY>

  eg. fix(type-hint): infer type of a constant for type checking INTELLIJ-1111
-->

## Description

<!--- Describe your changes in detail so reviewers have enough content on what this PR aims to achieve -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist

- [ ] New tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
- [ ] Changelog is updated accordingly.
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement).

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->